### PR TITLE
Added a Dart FFI based scenario with a null-dereference crash

### DIFF
--- a/features/fixtures/app/android/CMakeLists.txt
+++ b/features/fixtures/app/android/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 3.4.1)  # for example
+
+add_library( ffi_crashes
+             SHARED
+             ../ios/Runner/ffi_crashes.c )

--- a/features/fixtures/app/android/app/build.gradle
+++ b/features/fixtures/app/android/app/build.gradle
@@ -41,6 +41,14 @@ android {
         versionName flutterVersionName
     }
 
+    externalNativeBuild {
+        // Encapsulates your CMake build configurations.
+        cmake {
+            // Provides a relative path to your CMake build script.
+            path "../CMakeLists.txt"
+        }
+    }
+
     buildTypes {
         release {
             // TODO: Add your own signing config for the release build.

--- a/features/fixtures/app/ios/Runner.xcodeproj/project.pbxproj
+++ b/features/fixtures/app/ios/Runner.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
+		96D8AA0B27AC3E7C0032F493 /* ffi_crashes.c in Sources */ = {isa = PBXBuildFile; fileRef = 96D8AA0A27AC3E7C0032F493 /* ffi_crashes.c */; };
 		96E7620127A0669100628D7B /* Bugsnag in Frameworks */ = {isa = PBXBuildFile; productRef = 96E7620027A0669100628D7B /* Bugsnag */; };
 		96E7620A27A18A4800628D7B /* Scenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 96E7620927A18A4800628D7B /* Scenario.m */; };
 		96F00EF327AACC0100C218BB /* NativeCrashScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 96F00EF227AACC0100C218BB /* NativeCrashScenario.m */; };
@@ -39,6 +40,7 @@
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
 		7AFFD8ED1D35381100E5BB4D /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		7AFFD8EE1D35381100E5BB4D /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
+		96D8AA0A27AC3E7C0032F493 /* ffi_crashes.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = ffi_crashes.c; sourceTree = "<group>"; };
 		96E7620527A0785B00628D7B /* Scenario.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Scenario.h; sourceTree = "<group>"; };
 		96E7620927A18A4800628D7B /* Scenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Scenario.m; sourceTree = "<group>"; };
 		96F00EF127AACC0100C218BB /* NativeCrashScenario.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NativeCrashScenario.h; sourceTree = "<group>"; };
@@ -107,6 +109,7 @@
 		97C146F01CF9000F007C117D /* Runner */ = {
 			isa = PBXGroup;
 			children = (
+				96D8AA0A27AC3E7C0032F493 /* ffi_crashes.c */,
 				96E7620427A0685200628D7B /* Scenarios */,
 				7AFFD8ED1D35381100E5BB4D /* AppDelegate.h */,
 				7AFFD8EE1D35381100E5BB4D /* AppDelegate.m */,
@@ -240,6 +243,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				96D8AA0B27AC3E7C0032F493 /* ffi_crashes.c in Sources */,
 				978B8F6F1D3862AE00F588F7 /* AppDelegate.m in Sources */,
 				96E7620A27A18A4800628D7B /* Scenario.m in Sources */,
 				97C146F31CF9000F007C117D /* main.m in Sources */,

--- a/features/fixtures/app/ios/Runner/AppDelegate.m
+++ b/features/fixtures/app/ios/Runner/AppDelegate.m
@@ -8,6 +8,7 @@
 
 - (BOOL)application:(UIApplication *)application
     didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+    
     [GeneratedPluginRegistrant registerWithRegistry:self];
 
     FlutterViewController* controller = (FlutterViewController*)self.window.rootViewController;

--- a/features/fixtures/app/ios/Runner/ffi_crashes.c
+++ b/features/fixtures/app/ios/Runner/ffi_crashes.c
@@ -1,0 +1,11 @@
+#include <stddef.h>
+
+typedef struct {
+    int value;
+} dummy;
+
+__attribute__((visibility("default"))) __attribute__((used))
+void null_dereference(void) {
+    dummy *badPtr = NULL;
+    badPtr->value = 10;
+}

--- a/features/fixtures/app/lib/scenarios/ffi_crash_scenario.dart
+++ b/features/fixtures/app/lib/scenarios/ffi_crash_scenario.dart
@@ -1,0 +1,20 @@
+import 'dart:ffi'; // For FFI
+import 'dart:io'; // For Platform.isX
+
+import 'scenario.dart';
+
+class FFICrashScenario extends Scenario {
+  static final DynamicLibrary nativeCrashes = Platform.isAndroid
+      ? DynamicLibrary.open('libffi_crashes.so')
+      : DynamicLibrary.process();
+
+  final void Function() nullDereference = nativeCrashes
+      .lookup<NativeFunction<Void Function()>>('null_dereference')
+      .asFunction();
+
+  @override
+  Future<void> run() async {
+    await startBugsnag();
+    nullDereference();
+  }
+}

--- a/features/fixtures/app/lib/scenarios/scenarios.dart
+++ b/features/fixtures/app/lib/scenarios/scenarios.dart
@@ -2,6 +2,7 @@ import 'scenario.dart';
 
 import 'throw_exception_scenario.dart';
 import 'native_crash_scenario.dart';
+import 'ffi_crash_scenario.dart';
 
 class ScenarioInfo<T extends Scenario> {
   const ScenarioInfo(this.name, this.init);
@@ -14,4 +15,5 @@ class ScenarioInfo<T extends Scenario> {
 const List<ScenarioInfo<Scenario>> scenarios = [
   ScenarioInfo("ThrowExceptionScenario", ThrowExceptionScenario.new),
   ScenarioInfo("NativeCrashScenario", NativeCrashScenario.new),
+  ScenarioInfo("FFICrashScenario", FFICrashScenario.new),
 ];


### PR DESCRIPTION
## Goal
Added a test scenario to the fixture that crashes the app using a Dart FFI call to a null-dereference. These error should be caught by our existing native notifiers.

## Testing
Manual testing