### PR TITLE
Simple Makefile to help with building & testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+all: build lint test
+
+.PHONY: clean build aar example test lint
+
+clean:
+	cd bugsnag_flutter && flutter clean --suppress-analytics
+	cd example && flutter clean --suppress-analytics
+
+build: aar example
+
+aar:
+	cd bugsnag_flutter && flutter build aar --suppress-analytics
+
+example:
+	cd example && flutter build apk --suppress-analytics && flutter build ios --no-codesign --suppress-analytics
+
+test:
+	cd bugsnag_flutter && flutter test --suppress-analytics
+
+lint: aar
+	cd bugsnag_flutter && flutter analyze --suppress-analytics
+	cd bugsnag_flutter/android && ./gradlew \
+		-x compileDebugSources -x compileProfileSources -x compileReleaseSources \
+		-x compileDebugJavaWithJavac -x compileProfileJavaWithJavac -x compileReleaseJavaWithJavac \
+		lint

--- a/bugsnag_flutter/android/settings.gradle
+++ b/bugsnag_flutter/android/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'flutter'
+rootProject.name = 'bugsnag-flutter'


### PR DESCRIPTION
## Goal
Add a simple `Makefile` to the project to simplify building, unit testing and linting. Due to the iOS native layer being a plain Cocoapod, its scope is currently quite limited and it's only built as part of the Example application (as no standalone build exists for it).

- `make aar` will build a full Android AAR file
- `make lint` will check rules for Dart & Android
- `make test` will run the Dart unit tests
- `make example` will build the example application

## Testing
Manual testing