### PR TITLE
Bugsnag errorHandler

### DIFF
--- a/features/error_handler.feature
+++ b/features/error_handler.feature
@@ -1,0 +1,25 @@
+Feature: bugsnag.errorHandler
+
+  Scenario: Reports unhandled errors from guarded zones
+    When I configure the app to run in the "zone" state
+    And I run "ErrorHandlerScenario"
+    And I relaunch the app after a crash
+    And I configure Bugsnag for "ErrorHandlerScenario"
+    Then I wait to receive an error
+    And the error payload field "events" is an array with 1 elements
+    And the exception "errorClass" equals "_CastError"
+    And the error payload field "events.0.unhandled" is true
+    And the error payload field "events.0.exceptions.0.message" equals "Null check operator used on a null value"
+    And the error payload field "events.0.threads" is a non-empty array
+
+  Scenario: Reports unhandled errors from Future.onError
+    When I configure the app to run in the "future" state
+    And I run "ErrorHandlerScenario"
+    And I relaunch the app after a crash
+    And I configure Bugsnag for "ErrorHandlerScenario"
+    Then I wait to receive an error
+    And the error payload field "events" is an array with 1 elements
+    And the exception "errorClass" equals "String"
+    And the error payload field "events.0.unhandled" is true
+    And the error payload field "events.0.exceptions.0.message" equals "exception from the future"
+    And the error payload field "events.0.threads" is a non-empty array

--- a/features/fixtures/app/lib/scenarios/error_handler_scenario.dart
+++ b/features/fixtures/app/lib/scenarios/error_handler_scenario.dart
@@ -1,0 +1,28 @@
+import 'dart:async';
+
+import 'package:MazeRunner/scenarios/scenario.dart';
+import 'package:bugsnag_flutter/bugsnag.dart';
+
+class ErrorHandlerScenario extends Scenario {
+  @override
+  Future<void> run() async {
+    await startBugsnag();
+    await bugsnag.attach();
+
+    if (extraConfig?.contains("zone") == true) {
+      runZonedGuarded(
+        () {
+          String? nothingHere;
+          nothingHere!.substring(0, 10);
+        },
+        bugsnag.errorHandler,
+      );
+    } else if (extraConfig?.contains("future") == true) {
+      _throwAsyncException().onError(bugsnag.errorHandler);
+    }
+  }
+
+  Future<void> _throwAsyncException() async {
+    throw 'exception from the future';
+  }
+}

--- a/features/fixtures/app/lib/scenarios/scenarios.dart
+++ b/features/fixtures/app/lib/scenarios/scenarios.dart
@@ -1,4 +1,5 @@
 import 'attach_bugsnag_scenario.dart';
+import 'error_handler_scenario.dart';
 import 'ffi_crash_scenario.dart';
 import 'handled_exception_scenario.dart';
 import 'native_crash_scenario.dart';
@@ -19,4 +20,5 @@ const List<ScenarioInfo<Scenario>> scenarios = [
   ScenarioInfo('FFICrashScenario', FFICrashScenario.new),
   ScenarioInfo('AttachBugsnagScenario', AttachBugsnagScenario.new),
   ScenarioInfo('HandledExceptionScenario', HandledExceptionScenario.new),
+  ScenarioInfo('ErrorHandlerScenario', ErrorHandlerScenario.new),
 ];


### PR DESCRIPTION
## Goal
Provides a `bugsnag.errorHandler` function that can be used as a drop-in `onError` callback in common Dart functions, such as `runZonedGuarded` and `Future.onError`.

## Design
The function is returned as a property rather than being a declared function on the `Client`. This provides more flexibility and more closely matches the `onError` structure.

## Testing
A simple unit test for the `ChannelClient` to ensure reported errors are delivered, and 2 MazeRunner scenarios to check common use-cases (`runZonedGuarded` and `Future.onError`).