### PR TITLE
[PLAT-8032] Implement session APIs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 # A reference to Maze Runner is only needed for running tests locally and if committed it must be
 # portable for CI, e.g. a specific release.  However, leaving it commented out would mean quicker CI.
-gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v6.9.3'
+gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v6.9.6'
 
 # Use a specific branch
 #gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', branch: 'master'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/bugsnag/maze-runner
-  revision: 3230db9009a6f5ee9d8beac07deb0d87658521ea
-  tag: v6.9.3
+  revision: 83f500219cfd670a14079cf8ad4073e12cdf20ea
+  tag: v6.9.6
   specs:
-    bugsnag-maze-runner (6.9.3)
+    bugsnag-maze-runner (6.9.6)
       appium_lib (~> 11.2.0)
       bugsnag (~> 6.24)
       cucumber (~> 7.1)
@@ -31,7 +31,7 @@ GEM
       concurrent-ruby (~> 1.0)
     builder (3.2.4)
     childprocess (3.0.0)
-    concurrent-ruby (1.1.9)
+    concurrent-ruby (1.1.10)
     cucumber (7.1.0)
       builder (~> 3.2, >= 3.2.4)
       cucumber-core (~> 10.1, >= 10.1.0)

--- a/bugsnag_flutter/android/src/main/java/com/bugsnag/flutter/BugsnagFlutter.java
+++ b/bugsnag_flutter/android/src/main/java/com/bugsnag/flutter/BugsnagFlutter.java
@@ -220,6 +220,20 @@ class BugsnagFlutter {
         return null;
     }
 
+    Void startSession(@Nullable Void args) {
+        Bugsnag.startSession();
+        return null;
+    }
+
+    Void pauseSession(@Nullable Void args) {
+        Bugsnag.pauseSession();
+        return null;
+    }
+
+    Boolean resumeSession(@Nullable Void args) {
+        return Bugsnag.resumeSession();
+    }
+
     JSONObject createEvent(@Nullable JSONObject args) {
         if (args == null) {
             return null;

--- a/bugsnag_flutter/android/src/main/java/com/bugsnag/flutter/BugsnagFlutterPlugin.java
+++ b/bugsnag_flutter/android/src/main/java/com/bugsnag/flutter/BugsnagFlutterPlugin.java
@@ -33,6 +33,9 @@ public class BugsnagFlutterPlugin implements FlutterPlugin, MethodCallHandler {
         addFunction("addFeatureFlags",      bugsnag::addFeatureFlags);
         addFunction("clearFeatureFlag",     bugsnag::clearFeatureFlag);
         addFunction("clearFeatureFlags",    bugsnag::clearFeatureFlags);
+        addFunction("startSession",         bugsnag::startSession);
+        addFunction("pauseSession",         bugsnag::pauseSession);
+        addFunction("resumeSession",        bugsnag::resumeSession);
         addFunction("attach",               bugsnag::attach);
         addFunction("start",                bugsnag::start);
     }

--- a/bugsnag_flutter/ios/Classes/BugsnagFlutterPlugin.h
+++ b/bugsnag_flutter/ios/Classes/BugsnagFlutterPlugin.h
@@ -20,6 +20,10 @@
 
 - (void)start:(NSDictionary *)arguments;
 
+- (void)startSession:(NSDictionary *)arguments;
+- (void)pauseSession:(NSDictionary *)arguments;
+- (NSNumber *)resumeSession:(NSDictionary *)arguments;
+
 - (NSDictionary *)createEvent:(NSDictionary *)json;
 - (void)deliverEvent:(NSDictionary *)json;
 

--- a/bugsnag_flutter/ios/Classes/BugsnagFlutterPlugin.m
+++ b/bugsnag_flutter/ios/Classes/BugsnagFlutterPlugin.m
@@ -268,6 +268,18 @@ static NSString *NSStringOrNil(id value) {
     self.attached = YES;
 }
 
+- (void)startSession:(NSDictionary *)arguments {
+    [Bugsnag startSession];
+}
+
+- (void)pauseSession:(NSDictionary *)arguments {
+    [Bugsnag pauseSession];
+}
+
+- (NSNumber *)resumeSession:(NSDictionary *)arguments {
+    return @([Bugsnag resumeSession]);
+}
+
 - (NSDictionary *)createEvent:(NSDictionary *)json {
     NSDictionary *systemInfo = [BSG_KSSystemInfo systemInfo];
     BugsnagClient *client = Bugsnag.client;

--- a/bugsnag_flutter/lib/src/client.dart
+++ b/bugsnag_flutter/lib/src/client.dart
@@ -44,6 +44,12 @@ abstract class Client {
 
   Future<void> clearFeatureFlags();
 
+  Future<void> startSession();
+
+  Future<void> pauseSession();
+
+  Future<bool> resumeSession();
+
   Future<void> notify(
     dynamic error, {
     StackTrace? stackTrace,
@@ -117,6 +123,15 @@ class DelegateClient implements Client {
 
   @override
   Future<void> clearFeatureFlags() => client.clearFeatureFlags();
+
+  @override
+  Future<void> startSession() => client.startSession();
+
+  @override
+  Future<void> pauseSession() => client.pauseSession();
+
+  @override
+  Future<bool> resumeSession() => client.resumeSession();
 
   @override
   Future<void> notify(
@@ -202,6 +217,16 @@ class ChannelClient implements Client {
   @override
   Future<void> clearFeatureFlags() =>
       _channel.invokeMethod('clearFeatureFlags');
+
+  @override
+  Future<void> startSession() => _channel.invokeMethod('startSession');
+
+  @override
+  Future<void> pauseSession() => _channel.invokeMethod('pauseSession');
+
+  @override
+  Future<bool> resumeSession() async =>
+      await _channel.invokeMethod('resumeSession') as bool;
 
   @override
   void addOnBreadcrumb(OnBreadcrumbCallback onBreadcrumb) =>

--- a/features/fixtures/app/lib/main.dart
+++ b/features/fixtures/app/lib/main.dart
@@ -98,7 +98,7 @@ class _HomePageState extends State<MazeRunnerHomePage> {
     _sessionEndpointController = TextEditingController(
       text: const String.fromEnvironment(
         'bsg.endpoint.session',
-        defaultValue: 'http://bs-local.com:9339/session',
+        defaultValue: 'http://bs-local.com:9339/sessions',
       ),
     );
   }

--- a/features/fixtures/app/lib/scenarios/breadcrumbs_scenario.dart
+++ b/features/fixtures/app/lib/scenarios/breadcrumbs_scenario.dart
@@ -38,9 +38,3 @@ class BreadcrumbsScenario extends Scenario {
 
   bool ignoreAllBreadcrumbs(Breadcrumb _) => false;
 }
-
-void expect(dynamic actual, dynamic expected) {
-  if (actual != expected) {
-    throw AssertionError('Expected \'$expected\' but got \'$actual\'');
-  }
-}

--- a/features/fixtures/app/lib/scenarios/manual_sessions_scenario.dart
+++ b/features/fixtures/app/lib/scenarios/manual_sessions_scenario.dart
@@ -1,0 +1,21 @@
+import 'package:bugsnag_flutter/bugsnag.dart';
+
+import 'scenario.dart';
+
+class ManualSessionsScenario extends Scenario {
+  @override
+  Future<void> run() async {
+    await bugsnag.start(
+      autoTrackSessions: false,
+      endpoints: endpoints,
+    );
+    await bugsnag.notify(Exception('No session'));
+    await bugsnag.startSession();
+    await bugsnag.notify(Exception('Session started'));
+    await bugsnag.pauseSession();
+    await bugsnag.notify(Exception('Session paused'));
+    final resumed = await bugsnag.resumeSession();
+    expect(resumed, true);
+    await bugsnag.notify(Exception('Session resumed'));
+  }
+}

--- a/features/fixtures/app/lib/scenarios/scenario.dart
+++ b/features/fixtures/app/lib/scenarios/scenario.dart
@@ -14,3 +14,9 @@ abstract class Scenario {
 
   Future<void> run();
 }
+
+void expect(dynamic actual, dynamic expected) {
+  if (actual != expected) {
+    throw AssertionError('Expected \'$expected\' but got \'$actual\'');
+  }
+}

--- a/features/fixtures/app/lib/scenarios/scenarios.dart
+++ b/features/fixtures/app/lib/scenarios/scenarios.dart
@@ -4,6 +4,7 @@ import 'error_handler_scenario.dart';
 import 'feature_flags_scenario.dart';
 import 'ffi_crash_scenario.dart';
 import 'handled_exception_scenario.dart';
+import 'manual_sessions_scenario.dart';
 import 'native_crash_scenario.dart';
 import 'scenario.dart';
 import 'start_bugsnag_scenario.dart';
@@ -24,6 +25,7 @@ const List<ScenarioInfo<Scenario>> scenarios = [
   ScenarioInfo('FeatureFlagsScenario', FeatureFlagsScenario.new),
   ScenarioInfo('FFICrashScenario', FFICrashScenario.new),
   ScenarioInfo('HandledExceptionScenario', HandledExceptionScenario.new),
+  ScenarioInfo('ManualSessionsScenario', ManualSessionsScenario.new),
   ScenarioInfo('NativeCrashScenario', NativeCrashScenario.new),
   ScenarioInfo('StartBugsnagScenario', StartBugsnagScenario.new),
   ScenarioInfo('ThrowExceptionScenario', ThrowExceptionScenario.new),

--- a/features/sessions.feature
+++ b/features/sessions.feature
@@ -1,0 +1,12 @@
+Feature: Session Tracking
+
+  Scenario: Manual session tracking
+    Given I run "ManualSessionsScenario"
+    * I wait to receive a session
+    * I wait to receive 4 errors
+    Then the received errors match:
+      | exceptions.0.message | session   |
+      | No session           | null      |
+      | Session started      | @not_null |
+      | Session paused       | null      |
+      | Session resumed      | @not_null |


### PR DESCRIPTION
## Goal

Implement session APIs

## Testing

Adds a new scenario to test manually tracking sessions.

Maze runner required updating to fix the `the received errors match:` step.