### PR TITLE
flutter ErrorType should be named `dart`

### DIFF
--- a/bugsnag_flutter/android/src/main/java/com/bugsnag/android/InternalHooks.java
+++ b/bugsnag_flutter/android/src/main/java/com/bugsnag/android/InternalHooks.java
@@ -111,7 +111,7 @@ public class InternalHooks {
 
     private void fixErrorType(Map<String, Object> mappedError) {
         // Remove this once bugsnag-android supports Flutter ErrorTypes
-        if ("flutter".equals(mappedError.get("type"))) {
+        if ("dart".equals(mappedError.get("type"))) {
             mappedError.put("type", "android");
         }
     }

--- a/bugsnag_flutter/lib/src/model/event.dart
+++ b/bugsnag_flutter/lib/src/model/event.dart
@@ -154,8 +154,7 @@ class Error {
 
   Stacktrace stacktrace;
 
-  Error(this.errorClass, this.message, this.stacktrace)
-      : type = ErrorType.flutter;
+  Error(this.errorClass, this.message, this.stacktrace) : type = ErrorType.dart;
 
   Error.fromJson(Map<String, dynamic> json)
       : errorClass = json.safeGet('errorClass'),
@@ -177,7 +176,7 @@ class ErrorType {
   static const android = ErrorType._create('android');
   static const cocoa = ErrorType._create('cocoa');
   static const c = ErrorType._create('c');
-  static const flutter = ErrorType._create('flutter');
+  static const dart = ErrorType._create('dart');
 
   final String name;
 
@@ -200,7 +199,7 @@ class ErrorType {
     if (name == android.name) return android;
     if (name == cocoa.name) return cocoa;
     if (name == c.name) return c;
-    if (name == flutter.name) return flutter;
+    if (name == dart.name) return dart;
 
     return ErrorType._create(name);
   }

--- a/bugsnag_flutter/lib/src/model/stackframe.dart
+++ b/bugsnag_flutter/lib/src/model/stackframe.dart
@@ -64,7 +64,7 @@ class Stackframe {
         codeIdentifier = json.safeGet('codeIdentifier');
 
   Stackframe.fromStackFrame(StackFrame frame)
-      : type = ErrorType.flutter,
+      : type = ErrorType.dart,
         file = frame.packagePath,
         lineNumber = frame.line,
         columnNumber = frame.column,

--- a/bugsnag_flutter/lib/src/model/thread.dart
+++ b/bugsnag_flutter/lib/src/model/thread.dart
@@ -20,7 +20,7 @@ class Thread {
     this.name,
     this.state,
     bool? isErrorReportingThread,
-    this.type = ErrorType.flutter,
+    this.type = ErrorType.dart,
     required Stacktrace stacktrace,
   })  : _stacktrace = stacktrace,
         isErrorReportingThread = isErrorReportingThread == true;

--- a/bugsnag_flutter/test/error_factory_test.dart
+++ b/bugsnag_flutter/test/error_factory_test.dart
@@ -9,7 +9,7 @@ void main() {
       final error =
           ErrorFactory.instance.createError(Exception('this is a message'));
 
-      expect(error.type, equals(ErrorType.flutter));
+      expect(error.type, equals(ErrorType.dart));
       // a surprise _ appears!
       expect(error.errorClass, equals('_Exception'));
       expect(error.message, equals('this is a message'));
@@ -19,7 +19,7 @@ void main() {
     test('Exception with an object message', () {
       final error = ErrorFactory.instance.createError(Exception(main));
 
-      expect(error.type, equals(ErrorType.flutter));
+      expect(error.type, equals(ErrorType.dart));
       // a surprise _ appears!
       expect(error.errorClass, equals('_Exception'));
       expect(error.message,
@@ -32,7 +32,7 @@ void main() {
           FormatException('could not parse input', 'invalid input', 0);
       final error = ErrorFactory.instance.createError(exception);
 
-      expect(error.type, equals(ErrorType.flutter));
+      expect(error.type, equals(ErrorType.dart));
       expect(error.errorClass, equals('FormatException'));
       expect(
         error.message,
@@ -47,7 +47,7 @@ void main() {
       final flutterError = FlutterError('This is a FlutterError');
       final error = ErrorFactory.instance.createError(flutterError);
 
-      expect(error.type, equals(ErrorType.flutter));
+      expect(error.type, equals(ErrorType.dart));
       expect(error.errorClass, equals('FlutterError'));
       expect(error.message, equals('This is a FlutterError'));
       expect(error.stacktrace.length, greaterThan(3));
@@ -68,7 +68,7 @@ void main() {
 
       final error = ErrorFactory.instance.createError(flutterError);
 
-      expect(error.type, equals(ErrorType.flutter));
+      expect(error.type, equals(ErrorType.dart));
       expect(error.errorClass, equals('FlutterError'));
       expect(
         error.message,
@@ -84,7 +84,7 @@ void main() {
     test('BadlyBehavedError', () {
       final error = ErrorFactory.instance.createError(BadlyBehavedError());
 
-      expect(error.type, equals(ErrorType.flutter));
+      expect(error.type, equals(ErrorType.dart));
       expect(error.errorClass, equals('BadlyBehavedError'));
       expect(error.message, equals('[exception]: error in toString'));
       expect(error.stacktrace.length, greaterThan(3));
@@ -93,7 +93,7 @@ void main() {
     test('Thrown number', () {
       final error = ErrorFactory.instance.createError(123);
 
-      expect(error.type, equals(ErrorType.flutter));
+      expect(error.type, equals(ErrorType.dart));
       expect(error.errorClass, equals('int'));
       expect(error.message, equals('123'));
       expect(error.stacktrace.length, greaterThan(3));

--- a/bugsnag_flutter/test/model/error_test.dart
+++ b/bugsnag_flutter/test/model/error_test.dart
@@ -4,7 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   group('Error', () {
     test('ErrorType identical', () {
-      expect(ErrorType.flutter, same(ErrorType.forName('flutter')));
+      expect(ErrorType.dart, same(ErrorType.forName('dart')));
       expect(ErrorType.android, same(ErrorType.forName(('android'))));
       expect(ErrorType.cocoa, same(ErrorType.forName(('cocoa'))));
     });
@@ -17,7 +17,7 @@ void main() {
     });
 
     test('toString', () {
-      expect(ErrorType.flutter.toString(), equals('flutter'));
+      expect(ErrorType.dart.toString(), equals('dart'));
       expect(ErrorType.android.toString(), equals('android'));
       expect(ErrorType.cocoa.toString(), equals('cocoa'));
       expect(ErrorType.c.toString(), equals('c'));


### PR DESCRIPTION
## Goal
`ErrorType.flutter` should be named `ErrorType.dart` to align with pipeline expectations.

## Testing
Reworked existing tests to check for the new name.