### PR TITLE
Include the `method` in obfuscated / native reports

### DIFF
--- a/bugsnag_flutter/test/bugsnag_stacktrace_test.dart
+++ b/bugsnag_flutter/test/bugsnag_stacktrace_test.dart
@@ -20,6 +20,11 @@ void main() {
       );
 
       expect(
+        stacktrace.map((f) => f.method),
+        everyElement('_kDartIsolateSnapshotInstructions'),
+      );
+
+      expect(
         stacktrace.map((f) => f.frameAddress),
         equals(const [
           '0x1f8ae6',


### PR DESCRIPTION
## Goal
Added the `method` to obfuscated / native stack traces so that unsymbolicated stack traces will read a little more nicely in the Dashboard.

## Changeset
Wrapped the `offset` in a new `_Frame` class, and moved the frame parsing logic into `_Frame` as a static method in an attempt to separate it from the other stack parsing code.

## Testing
Manually tested, and added to the existing unit test for native obfuscated stack traces