### PR TITLE
Obfuscated stack traces should use absolute addresses

### DIFF
--- a/bugsnag_flutter/test/bugsnag_stacktrace_test.dart
+++ b/bugsnag_flutter/test/bugsnag_stacktrace_test.dart
@@ -27,13 +27,13 @@ void main() {
       expect(
         stacktrace.map((f) => f.frameAddress),
         equals(const [
-          '0x1f8ae6',
-          '0x272034',
-          '0x235dc7',
-          '0x231409',
-          '0x235291',
-          '0x231409',
-          '0x23d8a5',
+          '0x7c9f1063fae6',
+          '0x7c9f106b9034',
+          '0x7c9f1067cdc7',
+          '0x7c9f10678409',
+          '0x7c9f1067c291',
+          '0x7c9f10678409',
+          '0x7c9f106848a5',
         ]),
       );
     });


### PR DESCRIPTION
## Goal
Align our obfuscated stack-trace generation with the existing Dwarf processing logic, which assumes `frameAddress` is absolute rather than relative.

## Design
Switch to using the `abs` field in the stack traces as the `frameAddress`. This follows the logic in the Dart `native_stack_traces` tool: https://github.com/dart-lang/sdk/blob/main/pkg/native_stack_traces/lib/src/convert.dart#L122

## Testing
Modified existing tests to expect absolute addresses in `frameAddress` rather than relative addresses.