### PR TITLE
[PLAT-8294] Cocoa codeIdentifier

### DIFF
--- a/bugsnag_flutter/ios/Classes/BugsnagFlutterPlugin.m
+++ b/bugsnag_flutter/ios/Classes/BugsnagFlutterPlugin.m
@@ -11,6 +11,7 @@
 #import <Bugsnag/BugsnagHandledState.h>
 #import <Bugsnag/BugsnagNotifier.h>
 #import <Bugsnag/BugsnagSessionTracker.h>
+#import <Bugsnag/BugsnagStackframe+Private.h>
 #import <Bugsnag/BugsnagThread+Private.h>
 
 #import <objc/runtime.h>
@@ -309,6 +310,12 @@ static NSString *NSStringOrNil(id value) {
                                                     session:client.sessionTracker.runningSession];
     event.apiKey = client.configuration.apiKey;
     event.context = client.context;
+    
+    for (BugsnagStackframe *frame in error.stacktrace) {
+        if ([frame.type isEqualToString:@"dart"] && !frame.codeIdentifier) {
+            frame.codeIdentifier = event.app.dsymUuid;
+        }
+    }
     
     if (client.configuration.sendThreads == BSGThreadSendPolicyAlways) {
         event.threads = [BugsnagThread allThreads:YES callStackReturnAddresses:NSThread.callStackReturnAddresses];

--- a/features/fixtures/app/ios/Podfile
+++ b/features/fixtures/app/ios/Podfile
@@ -28,6 +28,8 @@ require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelpe
 flutter_ios_podfile_setup
 
 target 'Runner' do
+  # TODO: remove this before release
+  pod 'Bugsnag', :git => 'https://github.com/bugsnag/bugsnag-cocoa', :branch => 'flutter'
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
 end
 

--- a/features/handled_exception.feature
+++ b/features/handled_exception.feature
@@ -1,22 +1,32 @@
 Feature: bugsnag.notify
 
   Scenario: Notify with an Exception
-    When I run "HandledExceptionScenario"
-    Then I wait to receive an error
-    And the error is valid for the error reporting API version "4.0" for the "Flutter Bugsnag Notifier" notifier
-    And the exception "errorClass" equals "_Exception"
-    And the error payload field "events.0.unhandled" is false
-    And the error payload field "events.0.exceptions.0.message" equals "test error message"
-    And the error payload field "events.0.threads" is a non-empty array
+    Given I run "HandledExceptionScenario"
+    * I wait to receive an error
+    Then the error is valid for the error reporting API version "4.0" for the "Flutter Bugsnag Notifier" notifier
+    * the exception "errorClass" equals "_Exception"
+    * the exception "message" equals "test error message"
+    * the event "unhandled" is false
+    * the error payload field "events.0.threads" is a non-empty array
+    * the "file" of stack frame 5 equals "scenarios/handled_exception_scenario.dart"
+    * the "method" of stack frame 5 equals "run"
+    * the "lineNumber" of stack frame 5 equals 20
+    * on iOS, the "codeIdentifier" of stack frame 5 is not null
+    * on iOS, the "type" of stack frame 5 equals "dart"
 
   Scenario: Notify with a callback
-    When I configure the app to run in the "callback" state
-    And I run "HandledExceptionScenario"
-    Then I wait to receive an error
-    And the error is valid for the error reporting API version "4.0" for the "Flutter Bugsnag Notifier" notifier
-    And the exception "errorClass" equals "_Exception"
-    And the error payload field "events.0.unhandled" is true
-    And the error payload field "events.0.exceptions.0.message" equals "test error message"
-    And the error payload field "events.0.metaData.callback.message" equals "Hello, World!"
-    And the error payload field "events.0.breadcrumbs.0.name" equals "Crumbs!"
-    And the error payload field "events.0.threads" is a non-empty array
+    Given I configure the app to run in the "callback" state
+    * I run "HandledExceptionScenario"
+    * I wait to receive an error
+    Then the error is valid for the error reporting API version "4.0" for the "Flutter Bugsnag Notifier" notifier
+    * the exception "errorClass" equals "_Exception"
+    * the exception "message" equals "test error message"
+    * the event "unhandled" is true
+    * the error payload field "events.0.metaData.callback.message" equals "Hello, World!"
+    * the error payload field "events.0.breadcrumbs.0.name" equals "Crumbs!"
+    * the error payload field "events.0.threads" is a non-empty array
+    * the "file" of stack frame 5 equals "scenarios/handled_exception_scenario.dart"
+    * the "method" of stack frame 5 equals "run"
+    * the "lineNumber" of stack frame 5 equals 13
+    * on iOS, the "codeIdentifier" of stack frame 5 is not null
+    * on iOS, the "type" of stack frame 5 equals "dart"


### PR DESCRIPTION
## Goal

Ensure stack frames contain `codeIdentifier` on Cocoa, as required by back-end for symbolication.

## Changeset

`BugsnagFlutterPlugin` adds a `codeIdentifier` to dart frames.

Relies on
* https://github.com/bugsnag/bugsnag-cocoa/commit/73eac52934d4ada0259287b16e943b19c4d53aaa

## Testing

Updated existing scenario to verify presence of `codeIdentifier`.