### PR TITLE
Flush the Android EventStore on deliverEvent

### DIFF
--- a/bugsnag_flutter/android/src/main/java/com/bugsnag/android/InternalHooks.java
+++ b/bugsnag_flutter/android/src/main/java/com/bugsnag/android/InternalHooks.java
@@ -71,6 +71,10 @@ public class InternalHooks {
 
     public void deliverEvent(@NonNull Event event) {
         client.notifyInternal(event, null);
+
+        if (event.getImpl().getOriginalUnhandled()) {
+            client.getEventStore().flushAsync();
+        }
     }
 
     public JSONObject mapError(Error error) {

--- a/features/error_boundary_widget.feature
+++ b/features/error_boundary_widget.feature
@@ -2,11 +2,6 @@ Feature: ErrorBoundary Widget
 
   Scenario: Errors are reported by ErrorBoundary widgets
     Given I run "ErrorBoundaryWidgetScenario"
-
-    # TODO: PLAT-8234
-    And on Android, I relaunch the app
-    And on Android, I configure Bugsnag for "UnhandledExceptionScenario"
-
     And I wait to receive an error
     Then the error payload field "events" is an array with 1 elements
     And the exception "errorClass" equals "_Exception"

--- a/features/error_handler.feature
+++ b/features/error_handler.feature
@@ -3,9 +3,6 @@ Feature: bugsnag.errorHandler
   Scenario: Reports unhandled errors from guarded zones
     When I configure the app to run in the "zone" state
     And I run "ErrorHandlerScenario"
-    # TODO: PLAT-8234
-    And on Android, I relaunch the app
-    And on Android, I configure Bugsnag for "ErrorHandlerScenario"
     Then I wait to receive an error
     And the error is valid for the error reporting API version "4.0" for the "Flutter Bugsnag Notifier" notifier
     And the exception "errorClass" equals "_CastError"
@@ -16,9 +13,6 @@ Feature: bugsnag.errorHandler
   Scenario: Reports unhandled errors from Future.onError
     When I configure the app to run in the "future" state
     And I run "ErrorHandlerScenario"
-    # TODO: PLAT-8234
-    And on Android, I relaunch the app
-    And on Android, I configure Bugsnag for "ErrorHandlerScenario"
     Then I wait to receive an error
     And the error is valid for the error reporting API version "4.0" for the "Flutter Bugsnag Notifier" notifier
     And the exception "errorClass" equals "String"

--- a/features/unhandled_exception.feature
+++ b/features/unhandled_exception.feature
@@ -2,11 +2,6 @@ Feature: Unhandled Flutter Exceptions
 
   Scenario: Unhandled Flutter Exception
     When I run "UnhandledExceptionScenario"
-
-    # TODO: PLAT-8234
-    And on Android, I relaunch the app
-    And on Android, I configure Bugsnag for "UnhandledExceptionScenario"
-
     Then I wait to receive an error
     And the error payload field "events" is an array with 1 elements
     And the exception "errorClass" equals "_Exception"


### PR DESCRIPTION
## Goal
Have the Android notifier deliver Flutter errors without requiring an application restart.

## Design
Have the Flutter notifier flush the Android `EventStore` when delivering unhandled exceptions. This avoids requiring changes in the Android notifier and replicates the logic we would have added to it.

## Testing
Removed the Android restarts that were previously required for the end-to-end tests to pass.