### PR TITLE
Include the Dart className in the Stackframe.method

### DIFF
--- a/bugsnag_flutter/lib/src/model/stackframe.dart
+++ b/bugsnag_flutter/lib/src/model/stackframe.dart
@@ -68,7 +68,9 @@ class Stackframe {
         file = frame.packagePath,
         lineNumber = frame.line,
         columnNumber = frame.column,
-        method = frame.method;
+        method = (frame.className.isNotEmpty)
+            ? '${frame.className}.${frame.method}'
+            : frame.method;
 
   dynamic toJson() => {
         if (type != null) 'type': type!.name,

--- a/bugsnag_flutter/test/bugsnag_stacktrace_test.dart
+++ b/bugsnag_flutter/test/bugsnag_stacktrace_test.dart
@@ -93,7 +93,27 @@ void main() {
       expect(stacktrace[0].method, equals('main'));
       expect(stacktrace[0].file, endsWith('test/bugsnag_stacktrace_test.dart'));
     });
+
+    test('parses StackTrace objects from classes', () {
+      try {
+        BuggyClass().throwException();
+      } catch (_, stackTrace) {
+        final stacktrace = parseStackTraceString(stackTrace.toString());
+
+        expect(stacktrace, isNotNull);
+        expect(stacktrace!, hasLength(greaterThan(3)));
+
+        expect(stacktrace[0].method, equals('BuggyClass.throwException'));
+        expect(stacktrace[1].method, equals('main'));
+      }
+    });
   });
+}
+
+class BuggyClass {
+  void throwException() {
+    throw Exception('BuggyClass throwing exceptions');
+  }
 }
 
 const obfuscatedStackTrace =

--- a/bugsnag_flutter/test/model/stackframe_test.dart
+++ b/bugsnag_flutter/test/model/stackframe_test.dart
@@ -78,7 +78,10 @@ void main() {
         expect(stackframe.file, f.packagePath);
         expect(stackframe.lineNumber, f.line);
         expect(stackframe.columnNumber, f.column);
-        expect(stackframe.method, f.method);
+        expect(
+          stackframe.method,
+          f.className.isNotEmpty ? '${f.className}.${f.method}' : f.method,
+        );
       }
     });
   });

--- a/features/handled_exception.feature
+++ b/features/handled_exception.feature
@@ -9,7 +9,7 @@ Feature: bugsnag.notify
     * the event "unhandled" is false
     * the error payload field "events.0.threads" is a non-empty array
     * the "file" of stack frame 5 equals "scenarios/handled_exception_scenario.dart"
-    * the "method" of stack frame 5 equals "run"
+    * the "method" of stack frame 5 equals "HandledExceptionScenario.run"
     * the "lineNumber" of stack frame 5 equals 20
     * on iOS, the "codeIdentifier" of stack frame 5 is not null
     * on iOS, the "type" of stack frame 5 equals "dart"
@@ -26,7 +26,7 @@ Feature: bugsnag.notify
     * the error payload field "events.0.breadcrumbs.0.name" equals "Crumbs!"
     * the error payload field "events.0.threads" is a non-empty array
     * the "file" of stack frame 5 equals "scenarios/handled_exception_scenario.dart"
-    * the "method" of stack frame 5 equals "run"
+    * the "method" of stack frame 5 equals "HandledExceptionScenario.run"
     * the "lineNumber" of stack frame 5 equals 13
     * on iOS, the "codeIdentifier" of stack frame 5 is not null
     * on iOS, the "type" of stack frame 5 equals "dart"


### PR DESCRIPTION
## Goal
Include the Dart className in the `Stackframe.method` when it's available.

## Testing
Added the class name to tests that failed after the change to the Stackframe logic