### PR TITLE
Removed the OnSessionCallbacks from the Flutter API

### DIFF
--- a/bugsnag_flutter/lib/src/callbacks.dart
+++ b/bugsnag_flutter/lib/src/callbacks.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'model.dart';
 
 typedef OnErrorCallback = FutureOr<bool> Function(Event event);
-typedef OnSessionCallback = FutureOr<bool> Function(Session session);
 typedef OnBreadcrumbCallback = FutureOr<bool> Function(Breadcrumb breadcrumb);
 
 typedef _Callback<E> = FutureOr<bool> Function(E);

--- a/bugsnag_flutter/lib/src/client.dart
+++ b/bugsnag_flutter/lib/src/client.dart
@@ -346,14 +346,22 @@ class ChannelClient implements Client {
       if (buildID != null) 'buildID': buildID,
       if (errorContext != null) 'errorContext': errorContext,
       if (errorLibrary != null) 'errorLibrary': errorLibrary,
-      if (errorInfo.isNotEmpty) 'errorInformation': (StringBuffer()..writeAll(errorInfo, '\n')).toString(),
+      if (errorInfo.isNotEmpty)
+        'errorInformation':
+            (StringBuffer()..writeAll(errorInfo, '\n')).toString(),
       'defaultRouteName': PlatformDispatcher.instance.defaultRouteName,
-      'initialLifecycleState': PlatformDispatcher.instance.initialLifecycleState,
+      'initialLifecycleState':
+          PlatformDispatcher.instance.initialLifecycleState,
       if (lifecycleState != null) 'lifecycleState': lifecycleState,
     };
     final eventJson = await _channel.invokeMethod(
       'createEvent',
-      {'error': error, 'flutterMetadata': metadata, 'unhandled': unhandled, 'deliver': deliver},
+      {
+        'error': error,
+        'flutterMetadata': metadata,
+        'unhandled': unhandled,
+        'deliver': deliver
+      },
     );
 
     if (eventJson != null) {
@@ -399,7 +407,6 @@ class Bugsnag extends Client with DelegateClient {
     User? user,
     String? context,
     List<FeatureFlag>? featureFlags,
-    List<OnSessionCallback> onSession = const [],
     List<OnBreadcrumbCallback> onBreadcrumb = const [],
     List<OnErrorCallback> onError = const [],
   }) async {
@@ -476,7 +483,6 @@ class Bugsnag extends Client with DelegateClient {
     },
     Metadata? metadata,
     List<FeatureFlag>? featureFlags,
-    List<OnSessionCallback> onSession = const [],
     List<OnBreadcrumbCallback> onBreadcrumb = const [],
     List<OnErrorCallback> onError = const [],
   }) async {


### PR DESCRIPTION
## Goal
Remove the unused `OnSessionCallback` tyepdefs and parameters from the Flutter API.

## Testing
Relied on existing tests.