### PR TITLE
Remove the OnSession & OnBreadcrumb callbacks

### DIFF
--- a/bugsnag_flutter/lib/src/callbacks.dart
+++ b/bugsnag_flutter/lib/src/callbacks.dart
@@ -3,8 +3,6 @@ import 'dart:async';
 import 'model.dart';
 
 typedef OnErrorCallback = FutureOr<bool> Function(Event event);
-typedef OnSessionCallback = FutureOr<bool> Function(Session session);
-typedef OnBreadcrumbCallback = FutureOr<bool> Function(Breadcrumb breadcrumb);
 
 typedef _Callback<E> = FutureOr<bool> Function(E);
 

--- a/features/breadcrumbs.feature
+++ b/features/breadcrumbs.feature
@@ -9,5 +9,5 @@ Feature: Start Bugsnag from Flutter
     And the error payload field "events.0.breadcrumbs.0.type" equals "state"
     And the error payload field "events.0.breadcrumbs.1.metaData.foo" equals "bar"
     And the error payload field "events.0.breadcrumbs.1.metaData.object.test" equals "hello"
-    And the error payload field "events.0.breadcrumbs.1.name" equals "Manual breadcrumb from Flutter"
+    And the error payload field "events.0.breadcrumbs.1.name" equals "Manual breadcrumb"
     And the error payload field "events.0.breadcrumbs.1.type" equals "manual"

--- a/features/fixtures/app/lib/scenarios/breadcrumbs_scenario.dart
+++ b/features/fixtures/app/lib/scenarios/breadcrumbs_scenario.dart
@@ -9,32 +9,17 @@ class BreadcrumbsScenario extends Scenario {
       endpoints: endpoints,
     );
 
-    bugsnag.addOnBreadcrumb(ignoreAllBreadcrumbs);
-    bugsnag.removeOnBreadcrumb(ignoreAllBreadcrumbs);
-
-    bugsnag.addOnBreadcrumb((breadcrumb) {
-      if (breadcrumb.message.contains('ignore')) {
-        return false;
-      }
-      breadcrumb.message += ' from Flutter';
-      return true;
-    });
-
     await bugsnag.leaveBreadcrumb('Manual breadcrumb', metadata: {
       'foo': 'bar',
       'object': {'test': 'hello'}
     });
 
-    await bugsnag.leaveBreadcrumb('This breadcrumb should be ignored');
-
     final breadcrumbs = await bugsnag.getBreadcrumbs();
     expect(breadcrumbs[0].message, 'Bugsnag loaded');
     expect(breadcrumbs[0].type, BreadcrumbType.state);
-    expect(breadcrumbs[1].message, 'Manual breadcrumb from Flutter');
+    expect(breadcrumbs[1].message, 'Manual breadcrumb');
     expect(breadcrumbs[1].type, BreadcrumbType.manual);
 
     await bugsnag.notify(Exception('BreadcrumbsScenarioException'));
   }
-
-  bool ignoreAllBreadcrumbs(Breadcrumb _) => false;
 }


### PR DESCRIPTION
## Goal
Remove the OnSession and OnBreadcrumb callbacks form the Flutter notifier.

## Design
Due to the lack of platform integration in the Flutter notifier callbacks, these callbacks have very niche use cases currently.

## Testing
Removed the callbacks from the end2end scenarios.