### PR TITLE
Added missing Android-specific configuration options

### DIFF
--- a/bugsnag_flutter/lib/src/client.dart
+++ b/bugsnag_flutter/lib/src/client.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 import 'dart:ui';
 
 import 'package:bugsnag_flutter/src/error_factory.dart';
@@ -346,14 +347,22 @@ class ChannelClient implements Client {
       if (buildID != null) 'buildID': buildID,
       if (errorContext != null) 'errorContext': errorContext,
       if (errorLibrary != null) 'errorLibrary': errorLibrary,
-      if (errorInfo.isNotEmpty) 'errorInformation': (StringBuffer()..writeAll(errorInfo, '\n')).toString(),
+      if (errorInfo.isNotEmpty)
+        'errorInformation':
+            (StringBuffer()..writeAll(errorInfo, '\n')).toString(),
       'defaultRouteName': PlatformDispatcher.instance.defaultRouteName,
-      'initialLifecycleState': PlatformDispatcher.instance.initialLifecycleState,
+      'initialLifecycleState':
+          PlatformDispatcher.instance.initialLifecycleState,
       if (lifecycleState != null) 'lifecycleState': lifecycleState,
     };
     final eventJson = await _channel.invokeMethod(
       'createEvent',
-      {'error': error, 'flutterMetadata': metadata, 'unhandled': unhandled, 'deliver': deliver},
+      {
+        'error': error,
+        'flutterMetadata': metadata,
+        'unhandled': unhandled,
+        'deliver': deliver
+      },
     );
 
     if (eventJson != null) {
@@ -474,11 +483,14 @@ class Bugsnag extends Client with DelegateClient {
       BreadcrumbType.error,
       BreadcrumbType.manual
     },
+    Set<String>? projectPackages,
     Metadata? metadata,
     List<FeatureFlag>? featureFlags,
     List<OnSessionCallback> onSession = const [],
     List<OnBreadcrumbCallback> onBreadcrumb = const [],
     List<OnErrorCallback> onError = const [],
+    Directory? persistenceDirectory,
+    int? versionCode,
   }) async {
     // guarding WidgetsFlutterBinding.ensureInitialized() catches
     // async errors within the Flutter app
@@ -510,9 +522,14 @@ class Bugsnag extends Client with DelegateClient {
       'enabledBreadcrumbTypes': List<String>.from(
         enabledBreadcrumbTypes.map((e) => e._toName()),
       ),
+      if (projectPackages != null)
+        'projectPackages': List<String>.from(projectPackages),
       'metadata': metadata,
       'featureFlags': featureFlags,
       'notifier': _notifier,
+      if (persistenceDirectory != null)
+        'persistenceDirectory': persistenceDirectory.absolute.path,
+      if (versionCode != null) 'versionCode': versionCode,
     });
 
     final client = ChannelClient();

--- a/bugsnag_flutter/lib/src/model/stackframe.dart
+++ b/bugsnag_flutter/lib/src/model/stackframe.dart
@@ -65,7 +65,7 @@ class Stackframe {
 
   Stackframe.fromStackFrame(StackFrame frame)
       : type = ErrorType.dart,
-        file = frame.packagePath,
+        file = "${frame.packageScheme}:${frame.package}/${frame.packagePath}",
         lineNumber = frame.line,
         columnNumber = frame.column,
         method = (frame.className.isNotEmpty)

--- a/bugsnag_flutter/test/model/stackframe_test.dart
+++ b/bugsnag_flutter/test/model/stackframe_test.dart
@@ -75,7 +75,7 @@ void main() {
       final currentFrames = StackFrame.fromStackTrace(StackTrace.current);
       for (StackFrame f in currentFrames) {
         final stackframe = Stackframe.fromStackFrame(f);
-        expect(stackframe.file, f.packagePath);
+        expect(stackframe.file, endsWith(f.packagePath));
         expect(stackframe.lineNumber, f.line);
         expect(stackframe.columnNumber, f.column);
         expect(

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -33,8 +33,7 @@ android {
     }
 
     defaultConfig {
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId "com.bugsnag.bugsnag_flutter_example"
+        applicationId "com.bugsnag.examples.flutter"
         minSdkVersion flutter.minSdkVersion
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
@@ -43,7 +42,6 @@ android {
 
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
             // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig signingConfigs.debug
         }

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -1,28 +1,28 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.bugsnag.examples.flutter">
-   <application
-        android:label="bugsnag_flutter_example"
+
+    <application
         android:name="${applicationName}"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@mipmap/ic_launcher"
+        android:label="Bugsnag Flutter Example">
         <activity
             android:name=".MainActivity"
+            android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:exported="true"
+            android:hardwareAccelerated="true"
             android:launchMode="singleTop"
             android:theme="@style/LaunchTheme"
-            android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
-            android:hardwareAccelerated="true"
             android:windowSoftInputMode="adjustResize">
             <!-- Specifies an Android theme to apply to this Activity as soon as
                  the Android process has started. This theme is visible to the user
                  while the Flutter UI initializes. After that, this theme continues
                  to determine the Window background behind the Flutter UI. -->
             <meta-data
-              android:name="io.flutter.embedding.android.NormalTheme"
-              android:resource="@style/NormalTheme"
-              />
+                android:name="io.flutter.embedding.android.NormalTheme"
+                android:resource="@style/NormalTheme" />
             <intent-filter>
-                <action android:name="android.intent.action.MAIN"/>
-                <category android:name="android.intent.category.LAUNCHER"/>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.

--- a/example/android/app/src/main/java/com/bugsnag/examples/flutter/MainActivity.java
+++ b/example/android/app/src/main/java/com/bugsnag/examples/flutter/MainActivity.java
@@ -1,4 +1,4 @@
-package com.bugsnag.bugsnag_flutter_example;
+package com.bugsnag.examples.flutter;
 
 import android.os.Bundle;
 

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,4 +1,4 @@
-name: bugsnag_flutter_example
+name: examples
 description: Demonstrates how to use the flutter plugin.
 
 # The following line prevents the package from being accidentally published to

--- a/features/fixtures/app/android/app/build.gradle
+++ b/features/fixtures/app/android/app/build.gradle
@@ -34,7 +34,7 @@ android {
 
     defaultConfig {
         applicationId "com.bugsnag.flutter.test.app"
-        minSdkVersion 14
+        minSdkVersion 16
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/features/fixtures/app/lib/scenarios/project_packages_scenario.dart
+++ b/features/fixtures/app/lib/scenarios/project_packages_scenario.dart
@@ -1,0 +1,11 @@
+import 'package:bugsnag_flutter/bugsnag.dart';
+
+import 'scenario.dart';
+
+class ProjectPackagesScenario extends Scenario {
+  @override
+  Future<void> run() async {
+    await bugsnag.start(endpoints: endpoints, projectPackages: {'app'});
+    await bugsnag.notify(Exception());
+  }
+}

--- a/features/fixtures/app/lib/scenarios/scenarios.dart
+++ b/features/fixtures/app/lib/scenarios/scenarios.dart
@@ -8,6 +8,7 @@ import 'handled_exception_scenario.dart';
 import 'last_run_info_scenario.dart';
 import 'manual_sessions_scenario.dart';
 import 'native_crash_scenario.dart';
+import 'project_packages_scenario.dart';
 import 'scenario.dart';
 import 'start_bugsnag_scenario.dart';
 import 'throw_exception_scenario.dart';
@@ -32,6 +33,7 @@ const List<ScenarioInfo<Scenario>> scenarios = [
   ScenarioInfo('LastRunInfoScenario', LastRunInfoScenario.new),
   ScenarioInfo('ManualSessionsScenario', ManualSessionsScenario.new),
   ScenarioInfo('NativeCrashScenario', NativeCrashScenario.new),
+  ScenarioInfo('ProjectPackagesScenario', ProjectPackagesScenario.new),
   ScenarioInfo('StartBugsnagScenario', StartBugsnagScenario.new),
   ScenarioInfo('ThrowExceptionScenario', ThrowExceptionScenario.new),
   ScenarioInfo('UnhandledExceptionScenario', UnhandledExceptionScenario.new),

--- a/features/fixtures/app/lib/scenarios/start_bugsnag_scenario.dart
+++ b/features/fixtures/app/lib/scenarios/start_bugsnag_scenario.dart
@@ -8,6 +8,7 @@ class StartBugsnagScenario extends Scenario {
       apiKey: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
       appType: 'test',
       appVersion: '1.2.3',
+      versionCode: 4321,
       context: 'awesome',
       user: User(
         id: '123',

--- a/features/handled_exception.feature
+++ b/features/handled_exception.feature
@@ -8,7 +8,7 @@ Feature: bugsnag.notify
     * the exception "message" equals "test error message"
     * the event "unhandled" is false
     * the error payload field "events.0.threads" is a non-empty array
-    * the "file" of stack frame 5 equals "scenarios/handled_exception_scenario.dart"
+    * the "file" of stack frame 5 equals "package:MazeRunner/scenarios/handled_exception_scenario.dart"
     * the "method" of stack frame 5 equals "HandledExceptionScenario.run"
     * the "lineNumber" of stack frame 5 equals 20
     * on iOS, the "codeIdentifier" of stack frame 5 is not null
@@ -28,7 +28,7 @@ Feature: bugsnag.notify
     * the error payload field "events.0.metaData.callback.message" equals "Hello, World!"
     * the error payload field "events.0.breadcrumbs.0.name" equals "Crumbs!"
     * the error payload field "events.0.threads" is a non-empty array
-    * the "file" of stack frame 5 equals "scenarios/handled_exception_scenario.dart"
+    * the "file" of stack frame 5 equals "package:MazeRunner/scenarios/handled_exception_scenario.dart"
     * the "method" of stack frame 5 equals "HandledExceptionScenario.run"
     * the "lineNumber" of stack frame 5 equals 13
     * on iOS, the "codeIdentifier" of stack frame 5 is not null

--- a/features/project_packages.feature
+++ b/features/project_packages.feature
@@ -1,0 +1,11 @@
+Feature: projectPackages
+
+  @skip_ios
+  Scenario: Sends projectPackages with events
+    When I run "ProjectPackagesScenario"
+    Then I wait to receive an error
+    And the error is valid for the error reporting API version "4.0" for the "Flutter Bugsnag Notifier" notifier
+    And the exception "errorClass" equals "_Exception"
+    And the event "severity" equals "warning"
+    And the error payload field "events.0.projectPackages" is an array with 1 elements
+    And the event "projectPackages.0" equals "app"

--- a/features/start_bugsnag.feature
+++ b/features/start_bugsnag.feature
@@ -18,3 +18,4 @@ Feature: Start Bugsnag from Flutter
       | featureFlag  | variant |
       | demo-mode    |         |
       | sample-group | 123     |
+    And on Android, the event "app.versionCode" equals 4321

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -3,3 +3,33 @@
 BeforeAll do
   $api_key = 'abc12312312312312312312312312312'
 end
+
+Before('@skip_android') do |_scenario|
+  skip_this_scenario('Not compatible with Android') if platform? 'Android'
+end
+
+Before('@skip_ios') do |_scenario|
+  skip_this_scenario('Not compatible with iOS') if platform? 'iOS'
+end
+
+def current_platform
+  case Maze.config.farm
+  when :bs
+    Maze.driver.capabilities['os']
+  when :sl, :local
+    Maze.driver.capabilities['platformName']
+  when :none
+    Maze.config.os
+  else
+    Maze.driver.os
+  end
+end
+
+def platform?(name)
+  # case-insensitive string compare, also accepts symbols. examples:
+  #
+  # > is_platform? :android
+  # > is_platform? 'iOS'
+  # > is_platform? 'ios'
+  current_platform.casecmp(name.to_s).zero?
+end


### PR DESCRIPTION
## Goal

Allow the Android-specific `persistenceDirectory`, `versionCode` and `projectPackages` values to be configured directly from Flutter using `bugsnag.start`.

## Changeset

- Added `persistenceDirectory`, `versionCode` and `projectPackages` as optional parameters for `bugsnag.start`
- Fixed `apiKey` behaviour on Android to work in a pure Flutter setup
- Corrected the reporting of `Stackframe.file` to include the full Dart package-scheme, package, and path (was previous just the path)
- Corrected the Android package name for the Example app

## Testing
Added new end-to-end tests for `versionCode` and `projectPackages`
Manually checked the `persistenceDirectory` as there is no way to automate this testing