### PR TITLE
Make `Event.metadata` private

### DIFF
--- a/bugsnag_flutter/lib/src/model/event.dart
+++ b/bugsnag_flutter/lib/src/model/event.dart
@@ -29,7 +29,7 @@ class Event {
   AppWithState app;
 
   FeatureFlags featureFlags;
-  Metadata metadata;
+  final Metadata _metadata;
 
   bool get unhandled => _unhandled;
 
@@ -38,6 +38,15 @@ class Event {
     _severityReason.unhandledOverridden =
         (_unhandled != _originalUnhandled) ? true : null;
   }
+
+  void addMetadata(String section, MetadataSection metadata) =>
+      _metadata.addMetadata(section, metadata);
+
+  void clearMetadata(String section, [String? key]) =>
+      _metadata.clearMetadata(section, key);
+
+  MetadataSection? getMetadata(String section) =>
+      _metadata.getMetadata(section);
 
   Event.fromJson(Map<String, dynamic> json)
       : apiKey = json['apiKey'] as String?,
@@ -73,7 +82,7 @@ class Event {
         app = AppWithState.fromJson(json['app']),
         featureFlags = FeatureFlags.fromJson(
             json['featureFlags'].cast<Map<String, dynamic>>()),
-        metadata = json
+        _metadata = json
                 .safeGet<Map>('metaData')
                 ?.let((m) => Metadata.fromJson(m.cast())) ??
             Metadata();
@@ -95,7 +104,7 @@ class Event {
       'device': device,
       'app': app,
       'featureFlags': featureFlags,
-      'metaData': metadata,
+      'metaData': _metadata,
     };
   }
 }

--- a/bugsnag_flutter/lib/src/model/feature_flags.dart
+++ b/bugsnag_flutter/lib/src/model/feature_flags.dart
@@ -7,10 +7,10 @@ import '_model_extensions.dart';
 /// See also:
 /// - [FeatureFlags]
 class FeatureFlag {
-  String name;
-  String? variant;
+  final String name;
+  final String? variant;
 
-  FeatureFlag(this.name, [this.variant]);
+  const FeatureFlag(this.name, [this.variant]);
 
   FeatureFlag.fromJson(Map<String, Object?> json)
       : name = json.safeGet('featureFlag'),

--- a/bugsnag_flutter/test/bugsnag_test.dart
+++ b/bugsnag_flutter/test/bugsnag_test.dart
@@ -17,7 +17,7 @@ void main() {
       await bugsnag.attach(
         context: 'flutter-context',
         user: User(id: 'user-id-123', name: 'Bobby Tables'),
-        featureFlags: [
+        featureFlags: const [
           FeatureFlag('demo-mode'),
           FeatureFlag('sample-group', 'a'),
         ],

--- a/bugsnag_flutter/test/model/event_test.dart
+++ b/bugsnag_flutter/test/model/event_test.dart
@@ -48,9 +48,9 @@ void main() {
 
       event.featureFlags.addFeatureFlag('test-feature-flag');
 
-      event.metadata.clearMetadata('app');
-      event.metadata.clearMetadata('device');
-      event.metadata.addMetadata('test-section', const {'test-metadata': 1234});
+      event.clearMetadata('app');
+      event.clearMetadata('device');
+      event.addMetadata('test-section', const {'test-metadata': 1234});
 
       // we both mutate each list, and replace it - both are valid changes
 

--- a/features/fixtures/app/lib/scenarios/handled_exception_scenario.dart
+++ b/features/fixtures/app/lib/scenarios/handled_exception_scenario.dart
@@ -12,7 +12,7 @@ class HandledExceptionScenario extends Scenario {
       if (extraConfig?.contains('callback') == true) {
         await bugsnag.notify(e, callback: (event) {
           event.breadcrumbs = [Breadcrumb('Crumbs!')];
-          event.metadata.addMetadata('callback', {'message': 'Hello, World!'});
+          event.addMetadata('callback', {'message': 'Hello, World!'});
           event.unhandled = true;
           return true;
         });

--- a/features/fixtures/app/lib/scenarios/last_run_info_scenario.dart
+++ b/features/fixtures/app/lib/scenarios/last_run_info_scenario.dart
@@ -15,7 +15,7 @@ class LastRunInfoScenario extends Scenario {
 
     await bugsnag.notify(Exception('After launch'), callback: (event) async {
       final lastRunInfo = await bugsnag.getLastRunInfo() as LastRunInfo;
-      event.metadata.addMetadata('lastRunInfo', {
+      event.addMetadata('lastRunInfo', {
         'consecutiveLaunchCrashes': lastRunInfo.consecutiveLaunchCrashes,
         'crashed': lastRunInfo.crashed,
         'crashedDuringLaunch': lastRunInfo.crashedDuringLaunch,


### PR DESCRIPTION
## Goal
Align `Event` with the notifier-spec by making `Event.metadata` private and expose it's mutation methods on the `Event` class.

## Testing
Altered existing tests to use the new functions.