### PR TITLE
Removed the reference to `Event.metadata` in the Example app

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -13,6 +13,11 @@ steps:
     commands:
       - make lint
 
+  - label: Build Example App
+    timeout_in_minutes: 10
+    commands:
+      - make example
+
   #
   # iOS
   #

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -17,7 +17,7 @@ void main() async => bugsnag.start(
         (event) {
           if (event.unhandled) {
             // Metadata can be added on a per-event basis
-            event.metadata.addMetadata('info', const {'hint': 'Example'});
+            event.addMetadata('info', const {'hint': 'Example'});
           }
           // Return `true` to allow or `false` to prevent sending the event.
           return true;


### PR DESCRIPTION
## Goal
Fix the Example app by removing reference to `Event.metadata`

## Testing
The Example app is now built by CI to ensure this doesn't happen in future