### PR TITLE
Replace `Metadata` with a `Map` in `start`

### DIFF
--- a/bugsnag_flutter/lib/src/client.dart
+++ b/bugsnag_flutter/lib/src/client.dart
@@ -459,7 +459,7 @@ class Bugsnag extends Client with DelegateClient {
       BreadcrumbType.manual
     },
     Set<String>? projectPackages,
-    Metadata? metadata,
+    Map<String, Map<String, Object>>? metadata,
     List<FeatureFlag>? featureFlags,
     List<OnErrorCallback> onError = const [],
     Directory? persistenceDirectory,
@@ -497,7 +497,7 @@ class Bugsnag extends Client with DelegateClient {
       ),
       if (projectPackages != null)
         'projectPackages': List<String>.from(projectPackages),
-      'metadata': metadata,
+      if (metadata != null) 'metadata': Metadata(metadata),
       'featureFlags': featureFlags,
       'notifier': _notifier,
       if (persistenceDirectory != null)

--- a/features/fixtures/app/lib/scenarios/start_bugsnag_scenario.dart
+++ b/features/fixtures/app/lib/scenarios/start_bugsnag_scenario.dart
@@ -19,17 +19,17 @@ class StartBugsnagScenario extends Scenario {
       enabledReleaseStages: {'testing'},
       enabledBreadcrumbTypes: {BreadcrumbType.error},
       endpoints: endpoints,
-      featureFlags: [
+      featureFlags: const [
         FeatureFlag('demo-mode'),
         FeatureFlag('sample-group', '123'),
       ],
-      metadata: Metadata({
+      metadata: const {
         'custom': {
           'foo': 'bar',
           'secret': 'should be hidden',
           'password': 'not redacted'
         }
-      }),
+      },
       sendThreads: ThreadSendPolicy.never,
       runApp: () async {
         await bugsnag.notify(


### PR DESCRIPTION
## Goal
Replace the `Metadata` argument with a nullable `Map<Map<String, Object>>` in the `Bugsnag.start` method.

## Design
This will allow map literals to be used directly so that users don't have to wrap their maps in `Metadata` objects.

## Testing
Modified the existing tests covering the `start` function.