### PR TITLE
Fix the Example app package name for Android

### DIFF
--- a/example/android/app/src/debug/AndroidManifest.xml
+++ b/example/android/app/src/debug/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.bugsnag.bugsnag_flutter_example">
+    package="com.bugsnag.examples.flutter">
     <!-- Flutter needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->

--- a/example/android/app/src/profile/AndroidManifest.xml
+++ b/example/android/app/src/profile/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.bugsnag.bugsnag_flutter_example">
+    package="com.bugsnag.examples.flutter">
     <!-- Flutter needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->


### PR DESCRIPTION
## Goal
Fix the Example app debug & profile builds for Android by correcting the package name in the `AndroidManifest.xml`

## Testing
Tested by running the Example app from debug & profile builds