### PR TITLE
Make `Event.user` read-only

### DIFF
--- a/bugsnag_flutter/lib/src/model/event.dart
+++ b/bugsnag_flutter/lib/src/model/event.dart
@@ -22,8 +22,8 @@ class Event {
   Severity severity;
   final _SeverityReason _severityReason;
   final List<String> _projectPackages;
-  User user;
   final _Session? _session;
+  User _user;
 
   DeviceWithState device;
   AppWithState app;
@@ -32,6 +32,8 @@ class Event {
   final Metadata _metadata;
 
   bool get unhandled => _unhandled;
+
+  User get user => _user;
 
   set unhandled(bool unhandled) {
     _unhandled = unhandled;
@@ -47,6 +49,10 @@ class Event {
 
   MetadataSection? getMetadata(String section) =>
       _metadata.getMetadata(section);
+
+  void setUser({String? id, String? email, String? name}) {
+    _user = User(id: id, email: email, name: name);
+  }
 
   Event.fromJson(Map<String, dynamic> json)
       : apiKey = json['apiKey'] as String?,
@@ -74,10 +80,10 @@ class Event {
         _projectPackages =
             (json['projectPackages'] as List?)?.toList(growable: true).cast() ??
                 [],
-        user = User.fromJson(json['user']),
         _session = json
             .safeGet<Map>('session')
             ?.let((session) => _Session.fromJson(session.cast())),
+        _user = User.fromJson(json['user']),
         device = DeviceWithState.fromJson(json['device']),
         app = AppWithState.fromJson(json['app']),
         featureFlags = FeatureFlags.fromJson(

--- a/features/fixtures/app/lib/scenarios/handled_exception_scenario.dart
+++ b/features/fixtures/app/lib/scenarios/handled_exception_scenario.dart
@@ -13,6 +13,11 @@ class HandledExceptionScenario extends Scenario {
         await bugsnag.notify(e, callback: (event) {
           event.breadcrumbs = [Breadcrumb('Crumbs!')];
           event.addMetadata('callback', {'message': 'Hello, World!'});
+          event.setUser(
+            id: '3',
+            email: 'bugs.nag@bugsnag.com',
+            name: 'Bugs Nag',
+          );
           event.unhandled = true;
           return true;
         });

--- a/features/handled_exception.feature
+++ b/features/handled_exception.feature
@@ -10,7 +10,7 @@ Feature: bugsnag.notify
     * the error payload field "events.0.threads" is a non-empty array
     * the "file" of stack frame 5 equals "package:MazeRunner/scenarios/handled_exception_scenario.dart"
     * the "method" of stack frame 5 equals "HandledExceptionScenario.run"
-    * the "lineNumber" of stack frame 5 equals 20
+    * the "lineNumber" of stack frame 5 equals 25
     * on iOS, the "codeIdentifier" of stack frame 5 is not null
     * on iOS, the "type" of stack frame 5 equals "dart"
     * the event "metaData.flutter.defaultRouteName" equals "/"
@@ -36,3 +36,6 @@ Feature: bugsnag.notify
     * the event "metaData.flutter.defaultRouteName" equals "/"
     * the event "metaData.flutter.initialLifecycleState" is not null
     * the event "metaData.flutter.lifecycleState" is not null
+    * the event "user.id" equals "3"
+    * the event "user.email" equals "bugs.nag@bugsnag.com"
+    * the event "user.name" equals "Bugs Nag"


### PR DESCRIPTION
## Goal
`Event.user` should be a read-only property, with an `Event.setUser(id, email, name)` method in-line with other notifiers.

## Testing
Added a call to the new `setUser` method to the existing handled-error callback scenario