### PR TITLE
[PLAT-8354] Fix feature flags in Cocoa notify with callback

### DIFF
--- a/bugsnag_flutter/ios/Classes/BugsnagFlutterPlugin.m
+++ b/bugsnag_flutter/ios/Classes/BugsnagFlutterPlugin.m
@@ -336,6 +336,12 @@ static NSString *NSStringOrNil(id value) {
                                                     session:client.sessionTracker.runningSession];
     event.apiKey = client.configuration.apiKey;
     event.context = client.context;
+
+    // TODO: Expose BugsnagClient's featureFlagStore or provide a better way to create an event
+    id featureFlagStore = [client valueForKey:@"featureFlagStore"];
+    @synchronized (featureFlagStore) {
+        event.featureFlagStore = [featureFlagStore copy];
+    }
     
     for (BugsnagStackframe *frame in error.stacktrace) {
         if ([frame.type isEqualToString:@"dart"] && !frame.codeIdentifier) {


### PR DESCRIPTION
## Goal

Fix missing feature flags when calling `notify()` with a callback.

## Changeset

Sets the event's feature flags in the createEvent handler.

## Testing

Verified with `features/feature_flags.feature:14`