### PR TITLE
Add `autoDetectErrors` to the start & attach

### DIFF
--- a/bugsnag_flutter/android/src/main/java/com/bugsnag/flutter/BugsnagFlutter.java
+++ b/bugsnag_flutter/android/src/main/java/com/bugsnag/flutter/BugsnagFlutter.java
@@ -115,6 +115,7 @@ class BugsnagFlutter {
         configuration.setAppType(args.optString("appType", configuration.getAppType()));
         configuration.setAppVersion(args.optString("appVersion", configuration.getAppVersion()));
         configuration.setAutoTrackSessions(args.optBoolean("autoTrackSessions", configuration.getAutoTrackSessions()));
+        configuration.setAutoDetectErrors(args.optBoolean("autoDetectErrors", configuration.getAutoDetectErrors()));
         configuration.setContext(args.optString("context", configuration.getContext()));
         configuration.setLaunchDurationMillis(args.optLong("launchDurationMillis", configuration.getLaunchDurationMillis()));
         configuration.setMaxBreadcrumbs(args.optInt("maxBreadcrumbs", configuration.getMaxBreadcrumbs()));

--- a/bugsnag_flutter/ios/Classes/BugsnagFlutterPlugin.m
+++ b/bugsnag_flutter/ios/Classes/BugsnagFlutterPlugin.m
@@ -200,6 +200,7 @@ static NSString *NSStringOrNil(id value) {
     for (NSString *key in @[@"apiKey",
                             @"appType",
                             @"appVersion",
+                            @"autoDetectErrors",
                             @"autoTrackSessions",
                             @"bundleVersion",
                             @"context",

--- a/bugsnag_flutter/test/channel_client_test.dart
+++ b/bugsnag_flutter/test/channel_client_test.dart
@@ -12,7 +12,7 @@ void main() {
   group('ChannelClient', () {
     late ChannelClient client;
     setUp(() {
-      client = ChannelClient();
+      client = ChannelClient(true);
       channel.reset({
         'attach': true,
         'createEvent': _mockCreateEvent,

--- a/features/fixtures/app/lib/scenarios/native_crash_scenario.dart
+++ b/features/fixtures/app/lib/scenarios/native_crash_scenario.dart
@@ -1,11 +1,16 @@
 import 'package:MazeRunner/channels.dart';
+import 'package:bugsnag_flutter/bugsnag.dart';
 
 import 'scenario.dart';
 
 class NativeCrashScenario extends Scenario {
   @override
   Future<void> run() async {
-    await startBugsnag();
+    await bugsnag.start(
+      endpoints: endpoints,
+      autoDetectErrors: extraConfig?.contains('noDetectErrors') != true,
+    );
+
     await MazeRunnerChannels.runScenario('NativeCrashScenario');
   }
 }

--- a/features/fixtures/app/lib/scenarios/unhandled_exception_scenario.dart
+++ b/features/fixtures/app/lib/scenarios/unhandled_exception_scenario.dart
@@ -6,12 +6,16 @@ import 'scenario.dart';
 class UnhandledExceptionScenario extends Scenario {
   @override
   Future<void> run() async {
-    await startBugsnag();
+    await bugsnag.start(
+      endpoints: endpoints,
+      autoDetectErrors: extraConfig?.contains('noDetectErrors') != true,
+    );
+
     // Schedule and await to force everything onto the flutter stack.
     await SchedulerBinding.instance?.scheduleTask(
       () {
-      throw Exception('test error message');
-    },
+        throw Exception('test error message');
+      },
       Priority.animation,
     );
   }

--- a/features/unhandled_exception.feature
+++ b/features/unhandled_exception.feature
@@ -13,3 +13,13 @@ Feature: Unhandled Flutter Exceptions
     And the event "metaData.flutter.errorLibrary" equals "scheduler library"
     And the event "metaData.flutter.initialLifecycleState" is not null
     And the event "metaData.flutter.lifecycleState" is not null
+
+  Scenario: Unhandled Flutter Exception with autoDetectErrors=false
+    Given I configure the app to run in the "noDetectErrors" state
+    When I run "UnhandledExceptionScenario"
+    Then I should receive no error
+
+  Scenario: Unhandled Native Exception with autoDetectErrors=false
+    Given I configure the app to run in the "noDetectErrors" state
+    When I run "NativeCrashScenario"
+    Then I should receive no error


### PR DESCRIPTION
## Goal
Allow automatic error detection to be disabled by setting `autoDetectErrors: false`.

## Changeset
- Relay `autoDetectErrors` to the native layer in `bugsnag.start`
- `ChannelClient` won't install the `FlutterError.onError` hook if `autoDetectErrors = false`
- We don't guard `runApp` in an error-catching zone if `autoDetectErrors = false`

## Testing
Added extra `noDetectErrors` as a config option to the existing "unhandled", and "native" error scenarios to ensure that it can be disabled for both Dart & Native layers