### PR TITLE
Add `sendLaunchCrashesSynchronously` to `start`

### DIFF
--- a/bugsnag_flutter/android/src/main/java/com/bugsnag/flutter/BugsnagFlutter.java
+++ b/bugsnag_flutter/android/src/main/java/com/bugsnag/flutter/BugsnagFlutter.java
@@ -118,6 +118,7 @@ class BugsnagFlutter {
         configuration.setAutoDetectErrors(args.optBoolean("autoDetectErrors", configuration.getAutoDetectErrors()));
         configuration.setContext(args.optString("context", configuration.getContext()));
         configuration.setLaunchDurationMillis(args.optLong("launchDurationMillis", configuration.getLaunchDurationMillis()));
+        configuration.setSendLaunchCrashesSynchronously(args.optBoolean("sendLaunchCrashesSynchronously", configuration.getSendLaunchCrashesSynchronously()));
         configuration.setMaxBreadcrumbs(args.optInt("maxBreadcrumbs", configuration.getMaxBreadcrumbs()));
         configuration.setMaxPersistedEvents(args.optInt("maxPersistedEvents", configuration.getMaxPersistedEvents()));
         configuration.setMaxPersistedSessions(args.optInt("maxPersistedSessions", configuration.getMaxPersistedSessions()));

--- a/bugsnag_flutter/ios/Classes/BugsnagFlutterPlugin.m
+++ b/bugsnag_flutter/ios/Classes/BugsnagFlutterPlugin.m
@@ -210,7 +210,8 @@ static NSString *NSStringOrNil(id value) {
                             @"maxPersistedEvents",
                             @"maxPersistedSessions",
                             @"redactedKeys",
-                            @"releaseStage"]) {
+                            @"releaseStage",
+                            @"sendLaunchCrashesSynchronously"]) {
         id value = arguments[key];
         if (value && value != [NSNull null]) {
             [configuration setValue:value forKey:key];

--- a/bugsnag_flutter/lib/src/client.dart
+++ b/bugsnag_flutter/lib/src/client.dart
@@ -455,6 +455,7 @@ class Bugsnag extends Client with DelegateClient {
     bool autoDetectErrors = true,
     ThreadSendPolicy sendThreads = ThreadSendPolicy.always,
     int launchDurationMillis = 5000,
+    bool sendLaunchCrashesSynchronously = true,
     int appHangThresholdMillis = appHangThresholdFatalOnly,
     Set<String> redactedKeys = const {'password'},
     Set<String>? enabledReleaseStages,
@@ -499,6 +500,7 @@ class Bugsnag extends Client with DelegateClient {
       'autoDetectErrors': autoDetectErrors,
       'sendThreads': sendThreads._toName(),
       'launchDurationMillis': launchDurationMillis,
+      'sendLaunchCrashesSynchronously': sendLaunchCrashesSynchronously,
       'appHangThresholdMillis': appHangThresholdMillis,
       'redactedKeys': List<String>.from(redactedKeys),
       if (enabledReleaseStages != null)


### PR DESCRIPTION
## Goal
Allow `sendLaunchCrashesSynchronously` to be called in `bugsnag.start`

## Testing
Manually checked the option is sent through to the native layer, and set in configuration.