### PR TITLE
Implemented `discardClasses` as a configuration option

### DIFF
--- a/bugsnag_flutter/ios/Classes/BugsnagFlutterPlugin.m
+++ b/bugsnag_flutter/ios/Classes/BugsnagFlutterPlugin.m
@@ -209,7 +209,6 @@ static NSString *NSStringOrNil(id value) {
                             @"maxBreadcrumbs",
                             @"maxPersistedEvents",
                             @"maxPersistedSessions",
-                            @"redactedKeys",
                             @"releaseStage",
                             @"sendLaunchCrashesSynchronously"]) {
         id value = arguments[key];
@@ -217,7 +216,17 @@ static NSString *NSStringOrNil(id value) {
             [configuration setValue:value forKey:key];
         }
     }
-    
+
+    NSArray *redactedKeys = arguments[@"redactedKeys"];
+    if ([redactedKeys isKindOfClass:[NSArray class]]) {
+        configuration.redactedKeys = [NSSet setWithArray:redactedKeys];
+    }
+
+    NSArray *discardClasses = arguments[@"discardClasses"];
+    if ([discardClasses isKindOfClass:[NSArray class]]) {
+        configuration.discardClasses = [NSSet setWithArray:discardClasses];
+    }
+
     NSDictionary *user = arguments[@"user"];
     if ([user isKindOfClass:[NSDictionary class]]) {
         [configuration setUser:user[@"id"]

--- a/bugsnag_flutter/lib/src/client.dart
+++ b/bugsnag_flutter/lib/src/client.dart
@@ -458,6 +458,7 @@ class Bugsnag extends Client with DelegateClient {
     bool sendLaunchCrashesSynchronously = true,
     int appHangThresholdMillis = appHangThresholdFatalOnly,
     Set<String> redactedKeys = const {'password'},
+    Set<String> discardClasses = const {},
     Set<String>? enabledReleaseStages,
     Set<BreadcrumbType> enabledBreadcrumbTypes = const {
       BreadcrumbType.navigation,
@@ -503,6 +504,7 @@ class Bugsnag extends Client with DelegateClient {
       'sendLaunchCrashesSynchronously': sendLaunchCrashesSynchronously,
       'appHangThresholdMillis': appHangThresholdMillis,
       'redactedKeys': List<String>.from(redactedKeys),
+      'discardClasses': List<String>.from(discardClasses),
       if (enabledReleaseStages != null)
         'enabledReleaseStages': List<String>.from(enabledReleaseStages),
       'enabledBreadcrumbTypes': List<String>.from(

--- a/features/discard_classes.feature
+++ b/features/discard_classes.feature
@@ -1,0 +1,25 @@
+Feature: discardClasses
+
+  Scenario: Discard a handled exception
+    When I run "DiscardClassesScenario"
+    And I wait to receive an error
+    Then the error is valid for the error reporting API version "4.0" for the "Flutter Bugsnag Notifier" notifier with the apiKey "abc12312312312312312312312312312"
+    And the error payload field "events.0.breadcrumbs" is an array with 1 elements
+    And the exception "errorClass" equals "FormatException"
+
+  Scenario: Discard a handled exception with callback
+    Given I configure the app to run in the "callback" state
+    When I run "DiscardClassesScenario"
+    And I wait to receive an error
+    Then the error is valid for the error reporting API version "4.0" for the "Flutter Bugsnag Notifier" notifier with the apiKey "abc12312312312312312312312312312"
+    And the error payload field "events.0.breadcrumbs" is an array with 1 elements
+    And the event "metaData.origin.callback" is true
+    And the exception "errorClass" equals "FormatException"
+
+  Scenario: Discard an unhandled exception
+    Given I configure the app to run in the "unhandled" state
+    When I run "DiscardClassesScenario"
+    And I wait to receive an error
+    Then the error is valid for the error reporting API version "4.0" for the "Flutter Bugsnag Notifier" notifier with the apiKey "abc12312312312312312312312312312"
+    And the error payload field "events.0.breadcrumbs" is an array with 1 elements
+    And the exception "errorClass" equals "FormatException"

--- a/features/fixtures/app/lib/scenarios/discard_classes_scenario.dart
+++ b/features/fixtures/app/lib/scenarios/discard_classes_scenario.dart
@@ -1,0 +1,51 @@
+import 'package:bugsnag_flutter/bugsnag.dart';
+
+import 'scenario.dart';
+
+class DiscardClassesScenario extends Scenario {
+  @override
+  Future<void> run() async {
+    final withCallback = extraConfig?.contains('callback') == true;
+
+    await bugsnag.start(
+      endpoints: endpoints,
+      discardClasses: const {
+        '_Exception',
+      },
+      runApp: () async {
+        try {
+          throw Exception('this should be discarded');
+        } catch (e, stack) {
+          await _notifyError(e, stack, withCallback);
+        }
+
+        try {
+          int.parse('this is not a number');
+        } catch (e, stack) {
+          await _notifyError(e, stack, withCallback);
+        }
+
+        if (extraConfig?.contains('unhandled') == true) {
+          throw Exception('this should be discarded');
+        }
+      },
+    );
+  }
+
+  Future<void> _notifyError(
+    Object error,
+    StackTrace stack,
+    bool withCallback,
+  ) async {
+    await bugsnag.notify(
+      error,
+      stackTrace: stack,
+      callback: withCallback
+          ? (error) {
+              error.addMetadata('origin', const {'callback': true});
+              return true;
+            }
+          : null,
+    );
+  }
+}

--- a/features/fixtures/app/lib/scenarios/scenarios.dart
+++ b/features/fixtures/app/lib/scenarios/scenarios.dart
@@ -1,6 +1,7 @@
 import 'app_hang_scenario.dart';
 import 'attach_bugsnag_scenario.dart';
 import 'breadcrumbs_scenario.dart';
+import 'discard_classes_scenario.dart';
 import 'error_boundary_scenario.dart';
 import 'error_handler_scenario.dart';
 import 'feature_flags_scenario.dart';
@@ -27,6 +28,7 @@ const List<ScenarioInfo<Scenario>> scenarios = [
   ScenarioInfo('AppHangScenario', AppHangScenario.new),
   ScenarioInfo('AttachBugsnagScenario', AttachBugsnagScenario.new),
   ScenarioInfo('BreadcrumbsScenario', BreadcrumbsScenario.new),
+  ScenarioInfo('DiscardClassesScenario', DiscardClassesScenario.new),
   ScenarioInfo('ErrorBoundaryWidgetScenario', ErrorBoundaryWidgetScenario.new),
   ScenarioInfo('ErrorHandlerScenario', ErrorHandlerScenario.new),
   ScenarioInfo('FeatureFlagsScenario', FeatureFlagsScenario.new),

--- a/features/fixtures/app/lib/scenarios/start_bugsnag_scenario.dart
+++ b/features/fixtures/app/lib/scenarios/start_bugsnag_scenario.dart
@@ -1,5 +1,6 @@
-import 'package:MazeRunner/scenarios/scenario.dart';
 import 'package:bugsnag_flutter/bugsnag.dart';
+
+import 'scenario.dart';
 
 class StartBugsnagScenario extends Scenario {
   @override


### PR DESCRIPTION
## Goal
Allow `discardClasses` to be specified as a configuration option in `bugsnag.start`.

## Design
On Android additional steps are taken in the native layer of the Flutter notifier to discard Errors / Events, as the Android notifiers internal delivery does not filter the events itself.

On iOS the discardClasses are simply added to the configuration during startup and the existing delivery mechanism handles the discarding.

## Testing
Created a new test scenario to check the correct classes are discarded for both handled & unhandled Flutter errors.