### PR TITLE
Change `StackTrace` in `notify` to be a positional

### DIFF
--- a/bugsnag_flutter/lib/src/client.dart
+++ b/bugsnag_flutter/lib/src/client.dart
@@ -60,8 +60,8 @@ abstract class Client {
   Future<LastRunInfo?> getLastRunInfo();
 
   Future<void> notify(
-    dynamic error, {
-    StackTrace? stackTrace,
+    dynamic error,
+    StackTrace? stackTrace, {
     OnErrorCallback? callback,
   });
 
@@ -146,11 +146,11 @@ class DelegateClient implements Client {
 
   @override
   Future<void> notify(
-    dynamic error, {
-    StackTrace? stackTrace,
+    dynamic error,
+    StackTrace? stackTrace, {
     OnErrorCallback? callback,
   }) =>
-      client.notify(error, stackTrace: stackTrace, callback: callback);
+      client.notify(error, stackTrace, callback: callback);
 
   @override
   void addOnError(OnErrorCallback onError) => client.addOnError(onError);
@@ -298,14 +298,14 @@ class ChannelClient implements Client {
 
   @override
   Future<void> notify(
-    dynamic error, {
-    StackTrace? stackTrace,
+    dynamic error,
+    StackTrace? stackTrace, {
     OnErrorCallback? callback,
   }) {
     return _notifyInternal(error, false, null, stackTrace, callback);
   }
 
-  void _notifyUnhandled(dynamic error, StackTrace? stackTrace) async {
+  void _notifyUnhandled(dynamic error, StackTrace? stackTrace) {
     _notifyInternal(error, true, null, stackTrace, null);
   }
 

--- a/bugsnag_flutter/test/channel_client_test.dart
+++ b/bugsnag_flutter/test/channel_client_test.dart
@@ -32,7 +32,7 @@ void main() {
           return true;
         });
 
-        await client.notify('no error', stackTrace: StackTrace.current);
+        await client.notify('no error', StackTrace.current);
 
         expect(secondCallbackInvoked, isTrue);
       });
@@ -40,7 +40,7 @@ void main() {
       test('can block sending', () async {
         client.addOnError((event) => false);
 
-        await client.notify('no error', stackTrace: StackTrace.current);
+        await client.notify('no error', StackTrace.current);
 
         expect(channel['deliverEvent'], hasLength(0));
       });
@@ -52,7 +52,7 @@ void main() {
           return true;
         });
 
-        await client.notify('no error', stackTrace: StackTrace.current);
+        await client.notify('no error', StackTrace.current);
 
         expect(channel['deliverEvent'], hasLength(1));
         expect(channel['deliverEvent'][0]['threads'], hasLength(0));
@@ -67,7 +67,7 @@ void main() {
     group('Client.notify', () {
       test('delivers events in createEvent if possible', () async {
         channel.results['createEvent'] = null;
-        await client.notify('no error', stackTrace: StackTrace.current);
+        await client.notify('no error', StackTrace.current);
 
         expect(channel['createEvent'], hasLength(1));
         expect(channel['createEvent'][0]['deliver'], isTrue);
@@ -79,7 +79,7 @@ void main() {
         channel.results['createEvent'] = null;
         await client.notify(
           'no error',
-          stackTrace: StackTrace.fromString(obfuscatedStackTrace),
+          StackTrace.fromString(obfuscatedStackTrace),
         );
 
         expect(channel['createEvent'], hasLength(1));

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -45,8 +45,8 @@ class ExampleApp extends StatelessWidget {
   void _handledException() async {
     try {
       throw Exception('handled exception');
-    } catch (e) {
-      await bugsnag.notify(e);
+    } catch (e, stack) {
+      await bugsnag.notify(e, stack);
     }
   }
 

--- a/features/fixtures/app/lib/scenarios/attach_bugsnag_scenario.dart
+++ b/features/fixtures/app/lib/scenarios/attach_bugsnag_scenario.dart
@@ -11,7 +11,7 @@ class AttachBugsnagScenario extends Scenario {
         id: 'test-user-id',
         name: 'Old Man Tables',
       ),
-      featureFlags: [
+      featureFlags: const [
         FeatureFlag('demo-mode'),
         FeatureFlag('sample-group', '123'),
       ],
@@ -19,7 +19,7 @@ class AttachBugsnagScenario extends Scenario {
         if (extraConfig?.contains("handled") == true) {
           await bugsnag.notify(
             Exception('Exception with attached info'),
-            stackTrace: StackTrace.current,
+            StackTrace.current,
           );
         } else {
           throw Exception('Exception with attached info');

--- a/features/fixtures/app/lib/scenarios/breadcrumbs_scenario.dart
+++ b/features/fixtures/app/lib/scenarios/breadcrumbs_scenario.dart
@@ -20,6 +20,6 @@ class BreadcrumbsScenario extends Scenario {
     expect(breadcrumbs[1].message, 'Manual breadcrumb');
     expect(breadcrumbs[1].type, BreadcrumbType.manual);
 
-    await bugsnag.notify(Exception('BreadcrumbsScenarioException'));
+    await bugsnag.notify(Exception('BreadcrumbsScenarioException'), null);
   }
 }

--- a/features/fixtures/app/lib/scenarios/feature_flags_scenario.dart
+++ b/features/fixtures/app/lib/scenarios/feature_flags_scenario.dart
@@ -31,13 +31,13 @@ class FeatureFlagsScenario extends Scenario {
       throw Exception('Feature flags');
     } catch (e, stack) {
       if (extraConfig?.contains('callback') == true) {
-        await bugsnag.notify(e, stackTrace: stack, callback: (event) {
+        await bugsnag.notify(e, stack, callback: (event) {
           event.clearFeatureFlag('three');
           event.addFeatureFlag('callback', 'yes');
           return true;
         });
       } else {
-        await bugsnag.notify(e, stackTrace: stack);
+        await bugsnag.notify(e, stack);
       }
     }
   }

--- a/features/fixtures/app/lib/scenarios/handled_exception_scenario.dart
+++ b/features/fixtures/app/lib/scenarios/handled_exception_scenario.dart
@@ -8,9 +8,9 @@ class HandledExceptionScenario extends Scenario {
     await startBugsnag();
     try {
       throw Exception('test error message');
-    } catch (e) {
+    } catch (e, stack) {
       if (extraConfig?.contains('callback') == true) {
-        await bugsnag.notify(e, callback: (event) {
+        await bugsnag.notify(e, stack, callback: (event) {
           event.breadcrumbs = [Breadcrumb('Crumbs!')];
           event.addMetadata('callback', {'message': 'Hello, World!'});
           event.setUser(
@@ -22,7 +22,7 @@ class HandledExceptionScenario extends Scenario {
           return true;
         });
       } else {
-        await bugsnag.notify(e);
+        await bugsnag.notify(e, stack);
       }
     }
   }

--- a/features/fixtures/app/lib/scenarios/last_run_info_scenario.dart
+++ b/features/fixtures/app/lib/scenarios/last_run_info_scenario.dart
@@ -13,14 +13,18 @@ class LastRunInfoScenario extends Scenario {
 
     await bugsnag.markLaunchComplete();
 
-    await bugsnag.notify(Exception('After launch'), callback: (event) async {
-      final lastRunInfo = await bugsnag.getLastRunInfo() as LastRunInfo;
-      event.addMetadata('lastRunInfo', {
-        'consecutiveLaunchCrashes': lastRunInfo.consecutiveLaunchCrashes,
-        'crashed': lastRunInfo.crashed,
-        'crashedDuringLaunch': lastRunInfo.crashedDuringLaunch,
-      });
-      return true;
-    });
+    await bugsnag.notify(
+      Exception('After launch'),
+      null,
+      callback: (event) async {
+        final lastRunInfo = await bugsnag.getLastRunInfo() as LastRunInfo;
+        event.addMetadata('lastRunInfo', {
+          'consecutiveLaunchCrashes': lastRunInfo.consecutiveLaunchCrashes,
+          'crashed': lastRunInfo.crashed,
+          'crashedDuringLaunch': lastRunInfo.crashedDuringLaunch,
+        });
+        return true;
+      },
+    );
   }
 }

--- a/features/fixtures/app/lib/scenarios/manual_sessions_scenario.dart
+++ b/features/fixtures/app/lib/scenarios/manual_sessions_scenario.dart
@@ -9,13 +9,13 @@ class ManualSessionsScenario extends Scenario {
       autoTrackSessions: false,
       endpoints: endpoints,
     );
-    await bugsnag.notify(Exception('No session'));
+    await bugsnag.notify(Exception('No session'), null);
     await bugsnag.startSession();
-    await bugsnag.notify(Exception('Session started'));
+    await bugsnag.notify(Exception('Session started'), null);
     await bugsnag.pauseSession();
-    await bugsnag.notify(Exception('Session paused'));
+    await bugsnag.notify(Exception('Session paused'), null);
     final resumed = await bugsnag.resumeSession();
     expect(resumed, true);
-    await bugsnag.notify(Exception('Session resumed'));
+    await bugsnag.notify(Exception('Session resumed'), null);
   }
 }

--- a/features/fixtures/app/lib/scenarios/project_packages_scenario.dart
+++ b/features/fixtures/app/lib/scenarios/project_packages_scenario.dart
@@ -6,6 +6,6 @@ class ProjectPackagesScenario extends Scenario {
   @override
   Future<void> run() async {
     await bugsnag.start(endpoints: endpoints, projectPackages: {'app'});
-    await bugsnag.notify(Exception());
+    await bugsnag.notify(Exception(), null);
   }
 }

--- a/features/fixtures/app/lib/scenarios/start_bugsnag_scenario.dart
+++ b/features/fixtures/app/lib/scenarios/start_bugsnag_scenario.dart
@@ -34,7 +34,7 @@ class StartBugsnagScenario extends Scenario {
       runApp: () async {
         await bugsnag.notify(
           Exception('Exception with attached info'),
-          stackTrace: StackTrace.current,
+          StackTrace.current,
         );
       },
     );

--- a/features/handled_exception.feature
+++ b/features/handled_exception.feature
@@ -8,11 +8,11 @@ Feature: bugsnag.notify
     * the exception "message" equals "test error message"
     * the event "unhandled" is false
     * the error payload field "events.0.threads" is a non-empty array
-    * the "file" of stack frame 5 equals "package:MazeRunner/scenarios/handled_exception_scenario.dart"
-    * the "method" of stack frame 5 equals "HandledExceptionScenario.run"
-    * the "lineNumber" of stack frame 5 equals 25
-    * on iOS, the "codeIdentifier" of stack frame 5 is not null
-    * on iOS, the "type" of stack frame 5 equals "dart"
+    * the "file" of stack frame 0 equals "package:MazeRunner/scenarios/handled_exception_scenario.dart"
+    * the "method" of stack frame 0 equals "HandledExceptionScenario.run"
+    * the "lineNumber" of stack frame 0 equals 10
+    * on iOS, the "codeIdentifier" of stack frame 0 is not null
+    * on iOS, the "type" of stack frame 0 equals "dart"
     * the event "metaData.flutter.defaultRouteName" equals "/"
     * the event "metaData.flutter.initialLifecycleState" is not null
     * the event "metaData.flutter.lifecycleState" is not null
@@ -28,11 +28,11 @@ Feature: bugsnag.notify
     * the error payload field "events.0.metaData.callback.message" equals "Hello, World!"
     * the error payload field "events.0.breadcrumbs.0.name" equals "Crumbs!"
     * the error payload field "events.0.threads" is a non-empty array
-    * the "file" of stack frame 5 equals "package:MazeRunner/scenarios/handled_exception_scenario.dart"
-    * the "method" of stack frame 5 equals "HandledExceptionScenario.run"
-    * the "lineNumber" of stack frame 5 equals 13
-    * on iOS, the "codeIdentifier" of stack frame 5 is not null
-    * on iOS, the "type" of stack frame 5 equals "dart"
+    * the "file" of stack frame 0 equals "package:MazeRunner/scenarios/handled_exception_scenario.dart"
+    * the "method" of stack frame 0 equals "HandledExceptionScenario.run"
+    * the "lineNumber" of stack frame 0 equals 10
+    * on iOS, the "codeIdentifier" of stack frame 0 is not null
+    * on iOS, the "type" of stack frame 0 equals "dart"
     * on iOS, the event "app.dsymUUIDs.0" is not null
     * the event "metaData.flutter.defaultRouteName" equals "/"
     * the event "metaData.flutter.initialLifecycleState" is not null


### PR DESCRIPTION
## Goal
Simplify the most common call-type that will be made to `bugsnag.notify` by changing the `StackTrace` from a named argument to a positional argument.

## Design
The most common use of `notify` will be with caught `Exception`s and `Error`s, and these are commonly delivered along-side a `StackTrace`:
```dart
try {
  // buggy code
} catch (error, stackTrace) {
```

Having to pass the `StackTrace` as a named parameter made the calls more awkward: (`notify(error, stackTrace: stackTrace`). This change optimises the API for the most common calling style.

## Testing
Reworked the existing tests to call `notify` with the new argument structure.