### PR TITLE
Avoid conflicts with common Dart classes

### DIFF
--- a/bugsnag_flutter/lib/src/bugsnag_stacktrace.dart
+++ b/bugsnag_flutter/lib/src/bugsnag_stacktrace.dart
@@ -64,10 +64,10 @@ int? _parseBaseAddress(String line) {
   return null;
 }
 
-Stacktrace? _parseStackTrace(String stackTraceString) {
+BugsnagStacktrace? _parseStackTrace(String stackTraceString) {
   try {
     return StackFrame.fromStackTrace(StackTrace.fromString(stackTraceString))
-        .map(Stackframe.fromStackFrame)
+        .map(BugsnagStackframe.fromStackFrame)
         .toList();
   } catch (e) {
     return null;
@@ -76,18 +76,18 @@ Stacktrace? _parseStackTrace(String stackTraceString) {
 
 /// If possible parse the given [stackTrace] as an obfuscated native stackTrace.
 /// If the given `stackTrace` is not a valid native stack trace return `null`.
-Stacktrace? parseNativeStackTrace(String stackTrace) {
+BugsnagStacktrace? parseNativeStackTrace(String stackTrace) {
   final stackTraceLines = stackTrace.split('\n');
 
   String? buildId;
   int? baseOffset;
 
-  List<Stackframe> stacktrace = [];
+  List<BugsnagStackframe> stacktrace = [];
 
   for (final line in stackTraceLines) {
     if (line.contains('<asynchronous suspension>')) {
       stacktrace.add(
-        Stackframe.fromStackFrame(StackFrame.asynchronousSuspension),
+        BugsnagStackframe.fromStackFrame(StackFrame.asynchronousSuspension),
       );
     } else {
       buildId ??= _parseBuildId(line);
@@ -95,7 +95,7 @@ Stacktrace? parseNativeStackTrace(String stackTrace) {
       final frame = _Frame.parse(line);
 
       if (frame != null && baseOffset != null) {
-        stacktrace.add(Stackframe(
+        stacktrace.add(BugsnagStackframe(
           frameAddress: '0x' + frame.absoluteAddress.toRadixString(16),
           loadAddress: '0x' + baseOffset.toRadixString(16),
           codeIdentifier: buildId,
@@ -108,6 +108,6 @@ Stacktrace? parseNativeStackTrace(String stackTrace) {
   return (stacktrace.isNotEmpty && baseOffset != null) ? stacktrace : null;
 }
 
-Stacktrace? parseStackTraceString(String stackTrace) {
+BugsnagStacktrace? parseStackTraceString(String stackTrace) {
   return parseNativeStackTrace(stackTrace) ?? _parseStackTrace(stackTrace);
 }

--- a/bugsnag_flutter/lib/src/callbacks.dart
+++ b/bugsnag_flutter/lib/src/callbacks.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 
 import 'model.dart';
 
-typedef OnErrorCallback = FutureOr<bool> Function(Event event);
+typedef OnErrorCallback = FutureOr<bool> Function(BugsnagEvent event);
 
 typedef _Callback<E> = FutureOr<bool> Function(E);
 

--- a/bugsnag_flutter/lib/src/error_factory.dart
+++ b/bugsnag_flutter/lib/src/error_factory.dart
@@ -8,7 +8,7 @@ class ErrorFactory {
 
   const ErrorFactory._internal();
 
-  Error createError(dynamic error, [StackTrace? stackTrace]) {
+  BugsnagError createError(dynamic error, [StackTrace? stackTrace]) {
     // we favour the stackTrace on the `error` object, if one exists as this is
     // where the error was first thrown
     final errorStackTraceString = _getErrorStackTraceString(error);
@@ -19,7 +19,7 @@ class ErrorFactory {
         ? parseStackTraceString(stackTraceString)
         : null;
 
-    return Error(
+    return BugsnagError(
       error.runtimeType.toString(),
       _safeMessageForError(error),
       bugsnagStacktrace ?? _fallbackStacktrace(),
@@ -81,7 +81,7 @@ class ErrorFactory {
     return null;
   }
 
-  Stacktrace _fallbackStacktrace() =>
+  BugsnagStacktrace _fallbackStacktrace() =>
       parseStackTraceString(StackTrace.current.toString())!;
 
   /// Extract the probable "Display name" for an error based on it's type.

--- a/bugsnag_flutter/lib/src/model/breadcrumbs.dart
+++ b/bugsnag_flutter/lib/src/model/breadcrumbs.dart
@@ -1,26 +1,26 @@
 import '_model_extensions.dart';
 import 'metadata.dart';
 
-class Breadcrumb {
+class BugsnagBreadcrumb {
   String message;
   BreadcrumbType type;
   MetadataSection? metadata;
 
   final DateTime timestamp;
 
-  Breadcrumb(
+  BugsnagBreadcrumb(
     this.message, {
     this.type = BreadcrumbType.manual,
     this.metadata,
   }) : timestamp = DateTime.now().toUtc();
 
-  Breadcrumb.fromJson(Map<String, dynamic> json)
+  BugsnagBreadcrumb.fromJson(Map<String, dynamic> json)
       : message = json.safeGet('name'),
         timestamp = DateTime.parse(json['timestamp'] as String),
         type = BreadcrumbType.values.byName(json['type'] as String),
         metadata = json
             .safeGet<Map>('metaData')
-            ?.let((map) => Metadata.sanitizedMap(map.cast()));
+            ?.let((map) => BugsnagMetadata.sanitizedMap(map.cast()));
 
   dynamic toJson() => {
         'name': message,

--- a/bugsnag_flutter/lib/src/model/event.dart
+++ b/bugsnag_flutter/lib/src/model/event.dart
@@ -10,11 +10,11 @@ import 'stackframe.dart';
 import 'thread.dart';
 import 'user.dart';
 
-class Event {
+class BugsnagEvent {
   String? apiKey;
-  List<Error> errors;
-  List<Thread> threads;
-  List<Breadcrumb> breadcrumbs;
+  List<BugsnagError> errors;
+  List<BugsnagThread> threads;
+  List<BugsnagBreadcrumb> breadcrumbs;
   String? context;
   String? groupingHash;
   bool _unhandled;
@@ -29,7 +29,7 @@ class Event {
   AppWithState app;
 
   final FeatureFlags _featureFlags;
-  final Metadata _metadata;
+  final BugsnagMetadata _metadata;
 
   bool get unhandled => _unhandled;
 
@@ -61,21 +61,21 @@ class Event {
     _user = User(id: id, email: email, name: name);
   }
 
-  Event.fromJson(Map<String, dynamic> json)
+  BugsnagEvent.fromJson(Map<String, dynamic> json)
       : apiKey = json['apiKey'] as String?,
         errors = (json['exceptions'] as List?)
                 ?.cast<Map>()
-                .map((m) => Error.fromJson(m.cast()))
+                .map((m) => BugsnagError.fromJson(m.cast()))
                 .toList(growable: true) ??
             [],
         threads = (json['threads'] as List?)
                 ?.cast<Map>()
-                .map((m) => Thread.fromJson(m.cast()))
+                .map((m) => BugsnagThread.fromJson(m.cast()))
                 .toList(growable: true) ??
             [],
         breadcrumbs = (json['breadcrumbs'] as List?)
                 ?.cast<Map>()
-                .map((m) => Breadcrumb.fromJson(m.cast()))
+                .map((m) => BugsnagBreadcrumb.fromJson(m.cast()))
                 .toList(growable: true) ??
             [],
         context = json['context'] as String?,
@@ -97,8 +97,8 @@ class Event {
             json['featureFlags'].cast<Map<String, dynamic>>()),
         _metadata = json
                 .safeGet<Map>('metaData')
-                ?.let((m) => Metadata.fromJson(m.cast())) ??
-            Metadata();
+                ?.let((m) => BugsnagMetadata.fromJson(m.cast())) ??
+            BugsnagMetadata();
 
   dynamic toJson() {
     return {
@@ -169,22 +169,25 @@ enum Severity {
   info,
 }
 
-class Error {
+class BugsnagError {
   String errorClass;
   String? message;
-  ErrorType type;
+  BugsnagErrorType type;
 
-  Stacktrace stacktrace;
+  BugsnagStacktrace stacktrace;
 
-  Error(this.errorClass, this.message, this.stacktrace) : type = ErrorType.dart;
+  BugsnagError(this.errorClass, this.message, this.stacktrace)
+      : type = BugsnagErrorType.dart;
 
-  Error.fromJson(Map<String, dynamic> json)
+  BugsnagError.fromJson(Map<String, dynamic> json)
       : errorClass = json.safeGet('errorClass'),
         message = json.safeGet('message'),
-        type = json.safeGet<String>('type')?.let(ErrorType.forName) ??
-            (Platform.isAndroid ? ErrorType.android : ErrorType.cocoa),
-        stacktrace =
-            Stackframe.stacktraceFromJson((json['stacktrace'] as List).cast());
+        type = json.safeGet<String>('type')?.let(BugsnagErrorType.forName) ??
+            (Platform.isAndroid
+                ? BugsnagErrorType.android
+                : BugsnagErrorType.cocoa),
+        stacktrace = BugsnagStackframe.stacktraceFromJson(
+            (json['stacktrace'] as List).cast());
 
   dynamic toJson() => {
         'errorClass': errorClass,
@@ -194,20 +197,20 @@ class Error {
       };
 }
 
-class ErrorType {
-  static const android = ErrorType._create('android');
-  static const cocoa = ErrorType._create('cocoa');
-  static const c = ErrorType._create('c');
-  static const dart = ErrorType._create('dart');
+class BugsnagErrorType {
+  static const android = BugsnagErrorType._create('android');
+  static const cocoa = BugsnagErrorType._create('cocoa');
+  static const c = BugsnagErrorType._create('c');
+  static const dart = BugsnagErrorType._create('dart');
 
   final String name;
 
-  const ErrorType._create(this.name);
+  const BugsnagErrorType._create(this.name);
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-      other is ErrorType &&
+      other is BugsnagErrorType &&
           runtimeType == other.runtimeType &&
           name == other.name;
 
@@ -217,12 +220,12 @@ class ErrorType {
   @override
   String toString() => name;
 
-  factory ErrorType.forName(String name) {
+  factory BugsnagErrorType.forName(String name) {
     if (name == android.name) return android;
     if (name == cocoa.name) return cocoa;
     if (name == c.name) return c;
     if (name == dart.name) return dart;
 
-    return ErrorType._create(name);
+    return BugsnagErrorType._create(name);
   }
 }

--- a/bugsnag_flutter/lib/src/model/metadata.dart
+++ b/bugsnag_flutter/lib/src/model/metadata.dart
@@ -3,12 +3,12 @@ import '_model_extensions.dart';
 typedef MetadataSection = Map<String, Object>;
 typedef MetadataMap = Map<String, MetadataSection>;
 
-class Metadata {
+class BugsnagMetadata {
   final MetadataMap _map;
 
-  Metadata([MetadataMap map = const {}]) : this.fromJson(map);
+  BugsnagMetadata([MetadataMap map = const {}]) : this.fromJson(map);
 
-  Metadata.fromJson(Map<String, dynamic> json)
+  BugsnagMetadata.fromJson(Map<String, dynamic> json)
       : _map = json.map((key, val) => MapEntry(key, sanitizedMap(val)));
 
   void addMetadata(String section, MetadataSection metadata) {
@@ -32,7 +32,7 @@ class Metadata {
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-      other is Metadata &&
+      other is BugsnagMetadata &&
           runtimeType == other.runtimeType &&
           _map.deepEquals(other._map);
 

--- a/bugsnag_flutter/lib/src/model/notifier.dart
+++ b/bugsnag_flutter/lib/src/model/notifier.dart
@@ -1,22 +1,22 @@
 import '_model_extensions.dart';
 
-class Notifier {
+class BugsnagNotifier {
   String name;
   String version;
   String url;
 
-  List<Notifier> dependencies;
+  List<BugsnagNotifier> dependencies;
 
-  Notifier.fromJson(Map<String, dynamic> json)
+  BugsnagNotifier.fromJson(Map<String, dynamic> json)
       : name = json['name'],
         version = json['version'],
         url = json['url'],
         dependencies = json
                 .safeGet<List>('dependencies')
                 ?.cast<Map>()
-                .map((notifier) => Notifier.fromJson(notifier.cast()))
+                .map((notifier) => BugsnagNotifier.fromJson(notifier.cast()))
                 .toList(growable: true) ??
-            <Notifier>[];
+            <BugsnagNotifier>[];
 
   dynamic toJson() => {
         'name': name,

--- a/bugsnag_flutter/lib/src/model/session.dart
+++ b/bugsnag_flutter/lib/src/model/session.dart
@@ -1,11 +1,11 @@
 import 'user.dart';
 
-class Session {
+class BugsnagSession {
   String id;
   DateTime startedAt;
   User user;
 
-  Session.fromJson(Map<String, dynamic> json)
+  BugsnagSession.fromJson(Map<String, dynamic> json)
       : id = json['id'] as String,
         startedAt = DateTime.parse(json['startedAt']),
         user = User.fromJson(json['user'] as Map<String, dynamic>);

--- a/bugsnag_flutter/lib/src/model/stackframe.dart
+++ b/bugsnag_flutter/lib/src/model/stackframe.dart
@@ -3,8 +3,8 @@ import 'package:flutter/foundation.dart';
 import '_model_extensions.dart';
 import 'event.dart';
 
-class Stackframe {
-  ErrorType? type;
+class BugsnagStackframe {
+  BugsnagErrorType? type;
   String? file;
   int? lineNumber;
   int? columnNumber;
@@ -21,7 +21,7 @@ class Stackframe {
   String? machoVMAddress;
   String? codeIdentifier;
 
-  Stackframe({
+  BugsnagStackframe({
     this.type,
     this.file,
     this.lineNumber,
@@ -40,8 +40,8 @@ class Stackframe {
     this.codeIdentifier,
   });
 
-  Stackframe.fromJson(Map<String, Object?> json)
-      : type = json.safeGet<String>('type')?.let(ErrorType.forName),
+  BugsnagStackframe.fromJson(Map<String, Object?> json)
+      : type = json.safeGet<String>('type')?.let(BugsnagErrorType.forName),
         file = json.safeGet('file'),
         lineNumber = json.safeGet<num>('lineNumber')?.toInt(),
         columnNumber = json.safeGet<num>('columnNumber')?.toInt(),
@@ -58,8 +58,8 @@ class Stackframe {
         machoVMAddress = json.safeGet('machoVMAddress'),
         codeIdentifier = json.safeGet('codeIdentifier');
 
-  Stackframe.fromStackFrame(StackFrame frame)
-      : type = ErrorType.dart,
+  BugsnagStackframe.fromStackFrame(StackFrame frame)
+      : type = BugsnagErrorType.dart,
         file = "${frame.packageScheme}:${frame.package}/${frame.packagePath}",
         lineNumber = frame.line,
         columnNumber = frame.column,
@@ -90,8 +90,8 @@ class Stackframe {
   dynamic _addressValue(String? address) {
     if (address == null) {
       return null;
-    } else if (type == ErrorType.android ||
-        type == ErrorType.c && address.startsWith('0x')) {
+    } else if (type == BugsnagErrorType.android ||
+        type == BugsnagErrorType.c && address.startsWith('0x')) {
       return int.parse(address.substring(2), radix: 16);
     } else {
       return address;
@@ -106,8 +106,9 @@ class Stackframe {
     return null;
   }
 
-  static Stacktrace stacktraceFromJson(List<Map<String, dynamic>> json) =>
-      json.map(Stackframe.fromJson).toList();
+  static BugsnagStacktrace stacktraceFromJson(
+          List<Map<String, dynamic>> json) =>
+      json.map(BugsnagStackframe.fromJson).toList();
 }
 
-typedef Stacktrace = List<Stackframe>;
+typedef BugsnagStacktrace = List<BugsnagStackframe>;

--- a/bugsnag_flutter/lib/src/model/thread.dart
+++ b/bugsnag_flutter/lib/src/model/thread.dart
@@ -4,36 +4,38 @@ import '_model_extensions.dart';
 import 'event.dart';
 import 'stackframe.dart';
 
-class Thread {
+class BugsnagThread {
   String? id;
   String? name;
   String? state;
   bool isErrorReportingThread;
-  ErrorType type;
+  BugsnagErrorType type;
 
-  final Stacktrace _stacktrace;
+  final BugsnagStacktrace _stacktrace;
 
-  Stacktrace get stacktrace => _stacktrace;
+  BugsnagStacktrace get stacktrace => _stacktrace;
 
-  Thread({
+  BugsnagThread({
     this.id,
     this.name,
     this.state,
     bool? isErrorReportingThread,
-    this.type = ErrorType.dart,
-    required Stacktrace stacktrace,
+    this.type = BugsnagErrorType.dart,
+    required BugsnagStacktrace stacktrace,
   })  : _stacktrace = stacktrace,
         isErrorReportingThread = isErrorReportingThread == true;
 
-  Thread.fromJson(Map<String, dynamic> json)
+  BugsnagThread.fromJson(Map<String, dynamic> json)
       : id = json['id']?.toString(),
         name = json.safeGet('name'),
         state = json.safeGet('state'),
         isErrorReportingThread = json.safeGet('errorReportingThread') == true,
-        type = json.safeGet<String>('type')?.let(ErrorType.forName) ??
-            (Platform.isAndroid ? ErrorType.android : ErrorType.cocoa),
-        _stacktrace = json.safeGet<List>('stacktrace')?.let(
-                (frames) => Stackframe.stacktraceFromJson(frames.cast())) ??
+        type = json.safeGet<String>('type')?.let(BugsnagErrorType.forName) ??
+            (Platform.isAndroid
+                ? BugsnagErrorType.android
+                : BugsnagErrorType.cocoa),
+        _stacktrace = json.safeGet<List>('stacktrace')?.let((frames) =>
+                BugsnagStackframe.stacktraceFromJson(frames.cast())) ??
             [];
 
   dynamic toJson() => {

--- a/bugsnag_flutter/test/channel_client_test.dart
+++ b/bugsnag_flutter/test/channel_client_test.dart
@@ -128,7 +128,7 @@ void main() {
   });
 }
 
-Event _mockCreateEvent(arguments) => Event.fromJson({
+BugsnagEvent _mockCreateEvent(arguments) => BugsnagEvent.fromJson({
       'metaData': <String, dynamic>{},
       'severity': 'warning',
       'unhandled': arguments['unhandled'],

--- a/bugsnag_flutter/test/error_factory_test.dart
+++ b/bugsnag_flutter/test/error_factory_test.dart
@@ -9,7 +9,7 @@ void main() {
       final error =
           ErrorFactory.instance.createError(Exception('this is a message'));
 
-      expect(error.type, equals(ErrorType.dart));
+      expect(error.type, equals(BugsnagErrorType.dart));
       // a surprise _ appears!
       expect(error.errorClass, equals('_Exception'));
       expect(error.message, equals('this is a message'));
@@ -19,7 +19,7 @@ void main() {
     test('Exception with an object message', () {
       final error = ErrorFactory.instance.createError(Exception(main));
 
-      expect(error.type, equals(ErrorType.dart));
+      expect(error.type, equals(BugsnagErrorType.dart));
       // a surprise _ appears!
       expect(error.errorClass, equals('_Exception'));
       expect(error.message,
@@ -32,7 +32,7 @@ void main() {
           FormatException('could not parse input', 'invalid input', 0);
       final error = ErrorFactory.instance.createError(exception);
 
-      expect(error.type, equals(ErrorType.dart));
+      expect(error.type, equals(BugsnagErrorType.dart));
       expect(error.errorClass, equals('FormatException'));
       expect(
         error.message,
@@ -47,7 +47,7 @@ void main() {
       final flutterError = FlutterError('This is a FlutterError');
       final error = ErrorFactory.instance.createError(flutterError);
 
-      expect(error.type, equals(ErrorType.dart));
+      expect(error.type, equals(BugsnagErrorType.dart));
       expect(error.errorClass, equals('FlutterError'));
       expect(error.message, equals('This is a FlutterError'));
       expect(error.stacktrace.length, greaterThan(3));
@@ -68,7 +68,7 @@ void main() {
 
       final error = ErrorFactory.instance.createError(flutterError);
 
-      expect(error.type, equals(ErrorType.dart));
+      expect(error.type, equals(BugsnagErrorType.dart));
       expect(error.errorClass, equals('FlutterError'));
       expect(
         error.message,
@@ -84,7 +84,7 @@ void main() {
     test('BadlyBehavedError', () {
       final error = ErrorFactory.instance.createError(BadlyBehavedError());
 
-      expect(error.type, equals(ErrorType.dart));
+      expect(error.type, equals(BugsnagErrorType.dart));
       expect(error.errorClass, equals('BadlyBehavedError'));
       expect(error.message, equals('[exception]: error in toString'));
       expect(error.stacktrace.length, greaterThan(3));
@@ -93,7 +93,7 @@ void main() {
     test('Thrown number', () {
       final error = ErrorFactory.instance.createError(123);
 
-      expect(error.type, equals(ErrorType.dart));
+      expect(error.type, equals(BugsnagErrorType.dart));
       expect(error.errorClass, equals('int'));
       expect(error.message, equals('123'));
       expect(error.stacktrace.length, greaterThan(3));

--- a/bugsnag_flutter/test/model/breadcrumbs_test.dart
+++ b/bugsnag_flutter/test/model/breadcrumbs_test.dart
@@ -4,7 +4,8 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   group('Breadcrumbs', () {
     test('user breadcrumb toJson', () {
-      final breadcrumb = Breadcrumb('starting out on a journey', metadata: {});
+      final breadcrumb =
+          BugsnagBreadcrumb('starting out on a journey', metadata: {});
       final json = breadcrumb.toJson();
 
       expect(json['name'], equals('starting out on a journey'));
@@ -14,7 +15,7 @@ void main() {
     });
 
     test('breadcrumb with no metadata toJson', () {
-      final breadcrumb = Breadcrumb('oak', type: BreadcrumbType.log);
+      final breadcrumb = BugsnagBreadcrumb('oak', type: BreadcrumbType.log);
       final json = breadcrumb.toJson();
 
       expect(json['name'], equals('oak'));
@@ -30,7 +31,7 @@ void main() {
         'timestamp': '2022-03-03T02:15:50.405Z',
       };
 
-      final breadcrumb = Breadcrumb.fromJson(json);
+      final breadcrumb = BugsnagBreadcrumb.fromJson(json);
       expect(breadcrumb.message, equals('from all the way over the network'));
       expect(breadcrumb.type, equals(BreadcrumbType.request));
       expect(breadcrumb.metadata, isNull);
@@ -46,7 +47,7 @@ void main() {
         'metaData': {'some string': 'value goes here'},
       };
 
-      final breadcrumb = Breadcrumb.fromJson(json);
+      final breadcrumb = BugsnagBreadcrumb.fromJson(json);
       expect(breadcrumb.message, equals('from all the way over the network'));
       expect(breadcrumb.type, equals(BreadcrumbType.request));
       expect(breadcrumb.metadata, equals({'some string': 'value goes here'}));

--- a/bugsnag_flutter/test/model/error_test.dart
+++ b/bugsnag_flutter/test/model/error_test.dart
@@ -4,24 +4,25 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   group('Error', () {
     test('ErrorType identical', () {
-      expect(ErrorType.dart, same(ErrorType.forName('dart')));
-      expect(ErrorType.android, same(ErrorType.forName(('android'))));
-      expect(ErrorType.cocoa, same(ErrorType.forName(('cocoa'))));
+      expect(BugsnagErrorType.dart, same(BugsnagErrorType.forName('dart')));
+      expect(BugsnagErrorType.android,
+          same(BugsnagErrorType.forName(('android'))));
+      expect(BugsnagErrorType.cocoa, same(BugsnagErrorType.forName(('cocoa'))));
     });
 
     test('ErrorType equals', () {
       expect(
-        ErrorType.forName('testing'),
-        equals(ErrorType.forName('testing')),
+        BugsnagErrorType.forName('testing'),
+        equals(BugsnagErrorType.forName('testing')),
       );
     });
 
     test('toString', () {
-      expect(ErrorType.dart.toString(), equals('dart'));
-      expect(ErrorType.android.toString(), equals('android'));
-      expect(ErrorType.cocoa.toString(), equals('cocoa'));
-      expect(ErrorType.c.toString(), equals('c'));
-      expect(ErrorType.forName('testing').toString(), equals('testing'));
+      expect(BugsnagErrorType.dart.toString(), equals('dart'));
+      expect(BugsnagErrorType.android.toString(), equals('android'));
+      expect(BugsnagErrorType.cocoa.toString(), equals('cocoa'));
+      expect(BugsnagErrorType.c.toString(), equals('c'));
+      expect(BugsnagErrorType.forName('testing').toString(), equals('testing'));
     });
 
     test('from Android', () {
@@ -40,10 +41,10 @@ void main() {
         ]
       };
 
-      final error = Error.fromJson(androidError);
+      final error = BugsnagError.fromJson(androidError);
       expect(error.errorClass, equals('java.lang.NullPointerException'));
       expect(error.message, equals('user'));
-      expect(error.type, equals(ErrorType.android));
+      expect(error.type, equals(BugsnagErrorType.android));
 
       expect(error.stacktrace, hasLength(1));
       expect(error.stacktrace[0].file, equals('BaseCrashyActivity.kt'));
@@ -75,10 +76,10 @@ void main() {
         ],
       };
 
-      final error = Error.fromJson(iosError);
+      final error = BugsnagError.fromJson(iosError);
       expect(error.errorClass, equals('NSInvalidArgumentException'));
       expect(error.message, equals('my error message'));
-      expect(error.type, equals(ErrorType.cocoa));
+      expect(error.type, equals(BugsnagErrorType.cocoa));
 
       expect(error.stacktrace, hasLength(1));
       expect(error.stacktrace[0].method,

--- a/bugsnag_flutter/test/model/event_test.dart
+++ b/bugsnag_flutter/test/model/event_test.dart
@@ -10,30 +10,30 @@ import '_json_equals.dart';
 void main() {
   group('Event', () {
     test('Android deserialization / serialization', () async {
-      final expectedEvent = Event.fromJson(androidEventJson);
+      final expectedEvent = BugsnagEvent.fromJson(androidEventJson);
 
       final eventJsonFile =
           File('test/fixtures/android_event_serialization.json');
       final json = jsonDecode(await eventJsonFile.readAsString());
 
-      final event = Event.fromJson(json);
+      final event = BugsnagEvent.fromJson(json);
 
       expect(event, jsonEquals(expectedEvent));
     });
 
     test('iOS deserialization / serialization', () async {
-      final expectedEvent = Event.fromJson(iosEventJson);
+      final expectedEvent = BugsnagEvent.fromJson(iosEventJson);
 
       final eventJsonFile = File('test/fixtures/ios_event_serialization.json');
       final json = jsonDecode(await eventJsonFile.readAsString());
 
-      final event = Event.fromJson(json);
+      final event = BugsnagEvent.fromJson(json);
 
       expect(event, jsonEquals(expectedEvent));
     });
 
     test('Event is mutable', () async {
-      final event = Event.fromJson(iosEventJson);
+      final event = BugsnagEvent.fromJson(iosEventJson);
 
       event.apiKey = 'replacement-api-key';
       event.unhandled = false;

--- a/bugsnag_flutter/test/model/metadata_test.dart
+++ b/bugsnag_flutter/test/model/metadata_test.dart
@@ -5,12 +5,12 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   group('Metadata', () {
     test('is empty by default', () {
-      final metadata = Metadata();
+      final metadata = BugsnagMetadata();
       expect(metadata.getMetadata('test'), null);
     });
 
     test('addMetadata merges with existing content', () {
-      final metadata = Metadata({
+      final metadata = BugsnagMetadata({
         'test': {'a': 'b'}
       });
       metadata.addMetadata('test', {'x': 'y'});
@@ -18,7 +18,7 @@ void main() {
     });
 
     test('clearMetadata with no key removes entire section', () {
-      final metadata = Metadata({
+      final metadata = BugsnagMetadata({
         'test': {'a': 'b'}
       });
       metadata.clearMetadata('test');
@@ -26,7 +26,7 @@ void main() {
     });
 
     test('clearMetadata with key removes a single element', () {
-      final metadata = Metadata({
+      final metadata = BugsnagMetadata({
         'test': {'a': 'b', 'x': 'y'}
       });
       metadata.clearMetadata('test', 'a');
@@ -35,7 +35,7 @@ void main() {
 
     test('sanitizedMap replaces invalid types with strings', () {
       expect(
-        Metadata.sanitizedMap({
+        BugsnagMetadata.sanitizedMap({
           'array': [1, 2, 3, 4, 'foo'],
           'set': <dynamic>{},
           'number': 666,
@@ -63,8 +63,8 @@ void main() {
     });
 
     test('Metadata equality', () {
-      final m1 = Metadata();
-      final m2 = Metadata();
+      final m1 = BugsnagMetadata();
+      final m2 = BugsnagMetadata();
 
       m1.addMetadata('some new data', const {
         'number': 12345,

--- a/bugsnag_flutter/test/model/stackframe_test.dart
+++ b/bugsnag_flutter/test/model/stackframe_test.dart
@@ -11,7 +11,7 @@ void main() {
         'lineNumber': 158
       };
 
-      final stackframe = Stackframe.fromJson(json);
+      final stackframe = BugsnagStackframe.fromJson(json);
       expect(stackframe.method, 'android.os.Looper.loop');
       expect(stackframe.file, 'Looper.java');
       expect(stackframe.lineNumber, 158);
@@ -30,14 +30,14 @@ void main() {
         'type': 'c'
       };
 
-      final stackframe = Stackframe.fromJson(json);
+      final stackframe = BugsnagStackframe.fromJson(json);
       expect(stackframe.method, 'syscall');
       expect(stackframe.file, '/system/lib64/libc.so');
       expect(stackframe.lineNumber, 114912);
       expect(stackframe.frameAddress, '0x7fb4f670e0');
       expect(stackframe.symbolAddress, '0x7fb4f670c0');
       expect(stackframe.loadAddress, '0x7fb4f4b000');
-      expect(stackframe.type, ErrorType.c);
+      expect(stackframe.type, BugsnagErrorType.c);
 
       expect(stackframe.toJson(), json);
     });
@@ -55,7 +55,7 @@ void main() {
         'frameAddress': '0x1087cab00'
       };
 
-      final stackframe = Stackframe.fromJson(json);
+      final stackframe = BugsnagStackframe.fromJson(json);
       expect(stackframe.method,
           '\$s12macOSTestApp27BareboneTestHandledScenarioC3runyyF');
       expect(stackframe.machoVMAddress, '0x100000000');
@@ -74,7 +74,7 @@ void main() {
     test('from Dart', () {
       final currentFrames = StackFrame.fromStackTrace(StackTrace.current);
       for (StackFrame f in currentFrames) {
-        final stackframe = Stackframe.fromStackFrame(f);
+        final stackframe = BugsnagStackframe.fromStackFrame(f);
         expect(stackframe.file, endsWith(f.packagePath));
         expect(stackframe.lineNumber, f.line);
         expect(stackframe.columnNumber, f.column);

--- a/bugsnag_flutter/test/model/thread_test.dart
+++ b/bugsnag_flutter/test/model/thread_test.dart
@@ -18,11 +18,11 @@ void main() {
         ]
       };
 
-      final thread = Thread.fromJson(json);
+      final thread = BugsnagThread.fromJson(json);
 
       expect(thread.id, equals('24'));
       expect(thread.name, equals('main-one'));
-      expect(thread.type, equals(ErrorType.android));
+      expect(thread.type, equals(BugsnagErrorType.android));
       expect(thread.state, equals('RUNNABLE'));
       expect(thread.isErrorReportingThread, isFalse);
 
@@ -69,10 +69,10 @@ void main() {
         'state': 'sleeping',
       };
 
-      final thread = Thread.fromJson(json);
+      final thread = BugsnagThread.fromJson(json);
       expect(thread.id, equals('2345'));
       expect(thread.name, equals('Jit Worker'));
-      expect(thread.type, equals(ErrorType.c));
+      expect(thread.type, equals(BugsnagErrorType.c));
       expect(thread.state, equals('sleeping'));
       expect(thread.stacktrace, isEmpty);
       expect(thread.isErrorReportingThread, isFalse);
@@ -119,11 +119,11 @@ void main() {
         'type': 'cocoa'
       };
 
-      final thread = Thread.fromJson(json);
+      final thread = BugsnagThread.fromJson(json);
 
       expect(thread.id, equals('0'));
       expect(thread.isErrorReportingThread, isTrue);
-      expect(thread.type, ErrorType.cocoa);
+      expect(thread.type, BugsnagErrorType.cocoa);
 
       final stacktrace = thread.stacktrace;
       expect(stacktrace, hasLength(2));

--- a/features/fixtures/app/lib/scenarios/discard_classes_scenario.dart
+++ b/features/fixtures/app/lib/scenarios/discard_classes_scenario.dart
@@ -39,7 +39,7 @@ class DiscardClassesScenario extends Scenario {
   ) async {
     await bugsnag.notify(
       error,
-      stackTrace: stack,
+      stack,
       callback: withCallback
           ? (error) {
               error.addMetadata('origin', const {'callback': true});

--- a/features/fixtures/app/lib/scenarios/handled_exception_scenario.dart
+++ b/features/fixtures/app/lib/scenarios/handled_exception_scenario.dart
@@ -11,7 +11,7 @@ class HandledExceptionScenario extends Scenario {
     } catch (e, stack) {
       if (extraConfig?.contains('callback') == true) {
         await bugsnag.notify(e, stack, callback: (event) {
-          event.breadcrumbs = [Breadcrumb('Crumbs!')];
+          event.breadcrumbs = [BugsnagBreadcrumb('Crumbs!')];
           event.addMetadata('callback', {'message': 'Hello, World!'});
           event.setUser(
             id: '3',


### PR DESCRIPTION
## Goal
Avoid conflicting with existing common classes in Dart (such as `Error`) by prefixing our most common public model classes with `Bugsnag`.

## Changeset
Refactored much of the model to use the `Bugsnag` prefix excluding classes where it would pollute user code (for example: `FeatureFlag`).

List of non-prefixed types:
- BreadcrumbType
- FeatureFlag
- App
- AppWithState
- Device
- DeviceWithState
- Severity
- User

## Testing
Refactored existing tests to use the new class names where appropriate