### PR TITLE
Clearer constructor for EnabledErrorTypes

### DIFF
--- a/bugsnag_flutter/lib/src/config.dart
+++ b/bugsnag_flutter/lib/src/config.dart
@@ -6,8 +6,14 @@ class EnabledErrorTypes {
   final bool appHangs;
   final bool anrs;
 
-  const EnabledErrorTypes(this.unhandledExceptions, this.crashes, this.ooms,
-      this.thermalKills, this.appHangs, this.anrs);
+  const EnabledErrorTypes({
+    this.unhandledExceptions = true,
+    this.crashes = true,
+    this.ooms = true,
+    this.thermalKills = true,
+    this.appHangs = true,
+    this.anrs = true,
+  });
 
   dynamic toJson() => {
         'unhandledExceptions': unhandledExceptions,
@@ -18,8 +24,7 @@ class EnabledErrorTypes {
         'anrs': anrs
       };
 
-  static const EnabledErrorTypes all =
-      EnabledErrorTypes(true, true, true, true, true, true);
+  static const EnabledErrorTypes all = EnabledErrorTypes();
 }
 
 class EndpointConfiguration {


### PR DESCRIPTION
## Goal
Make the creation of `EnabledErrorTypes` less awkward.

## Design
Each error type is now a named argument to the constructor with a default value of `true`

## Testing
Relied on existing testing