### PR TITLE
Remove all native config from attach

### DIFF
--- a/bugsnag_flutter/android/src/main/java/com/bugsnag/flutter/BugsnagFlutter.java
+++ b/bugsnag_flutter/android/src/main/java/com/bugsnag/flutter/BugsnagFlutter.java
@@ -66,19 +66,6 @@ class BugsnagFlutter {
             throw new IllegalStateException("bugsnag.attach() can only be called once the native layer has already been started, have you called Bugsnag.start() from your Android code?");
         }
 
-        if (args != null) {
-            JSONObject user = args.optJSONObject("user");
-            if (user != null) {
-                setUser(user);
-            }
-
-            if (args.has("context")) {
-                setContext(args);
-            }
-        }
-
-        addFeatureFlags(args.optJSONArray("featureFlags"));
-
         client = new InternalHooks(nativeClient);
 
         Notifier notifier = client.getNotifier();

--- a/bugsnag_flutter/ios/Classes/BugsnagFlutterPlugin.m
+++ b/bugsnag_flutter/ios/Classes/BugsnagFlutterPlugin.m
@@ -156,19 +156,6 @@ static NSString *NSStringOrNil(id value) {
          @"bugsnag.attach() can only be called once the native layer has already been started, have you called [Bugsnag start] from your iOS code?"];
     }
 
-    if ([arguments[@"user"] isKindOfClass:[NSDictionary class]]) {
-        [self setUser:arguments[@"user"]];
-    }
-    
-    if ([arguments[@"context"] isKindOfClass:[NSString class]]) {
-        [self setContext:arguments];
-    }
-    
-    NSArray *featureFlags = arguments[@"featureFlags"];
-    if ([featureFlags isKindOfClass:[NSArray class]]) {
-        [self addFeatureFlags:featureFlags];
-    }
-    
     NSDictionary *notifier = arguments[@"notifier"];
     Bugsnag.client.notifier.name = notifier[@"name"];
     Bugsnag.client.notifier.version = notifier[@"version"];

--- a/bugsnag_flutter/lib/src/client.dart
+++ b/bugsnag_flutter/lib/src/client.dart
@@ -386,10 +386,7 @@ class Bugsnag extends Client with DelegateClient {
   /// * [addOnError]
   Future<void> attach({
     FutureOr<void> Function()? runApp,
-    User? user,
-    String? context,
     bool autoDetectErrors = true,
-    List<FeatureFlag>? featureFlags,
     List<OnErrorCallback> onError = const [],
   }) async {
     // make sure we can use Channels before calling runApp
@@ -399,9 +396,6 @@ class Bugsnag extends Client with DelegateClient {
     );
 
     await ChannelClient._channel.invokeMethod('attach', {
-      if (user != null) 'user': user,
-      if (context != null) 'context': context,
-      if (featureFlags != null) 'featureFlags': featureFlags,
       'notifier': _notifier,
     });
 

--- a/bugsnag_flutter/test/bugsnag_test.dart
+++ b/bugsnag_flutter/test/bugsnag_test.dart
@@ -14,29 +14,9 @@ void main() {
     test('attach', () async {
       channel.results['attach'] = true;
 
-      await bugsnag.attach(
-        context: 'flutter-context',
-        user: User(id: 'user-id-123', name: 'Bobby Tables'),
-        featureFlags: const [
-          FeatureFlag('demo-mode'),
-          FeatureFlag('sample-group', 'a'),
-        ],
-      );
+      await bugsnag.attach();
 
       expect(channel['attach'], hasLength(1));
-
-      dynamic attach = channel['attach'][0];
-      expect(attach['user']['id'], equals('user-id-123'));
-      expect(attach['user']['name'], equals('Bobby Tables'));
-
-      expect(attach['featureFlags'], hasLength(2));
-      expect(
-        attach['featureFlags'],
-        equals(const [
-          {'featureFlag': 'demo-mode'},
-          {'featureFlag': 'sample-group', 'variant': 'a'},
-        ]),
-      );
     });
 
     test('runApp catches async exceptions', () async {

--- a/features/fixtures/app/lib/scenarios/attach_bugsnag_scenario.dart
+++ b/features/fixtures/app/lib/scenarios/attach_bugsnag_scenario.dart
@@ -6,16 +6,16 @@ class AttachBugsnagScenario extends Scenario {
   Future<void> run() async {
     await startNativeNotifier();
     await bugsnag.attach(
-      context: 'flutter-test-context',
-      user: User(
-        id: 'test-user-id',
-        name: 'Old Man Tables',
-      ),
-      featureFlags: const [
-        FeatureFlag('demo-mode'),
-        FeatureFlag('sample-group', '123'),
-      ],
       runApp: () async {
+        await Future.wait([
+          bugsnag.setContext('flutter-test-context'),
+          bugsnag.setUser(id: 'test-user-id', name: 'Old Man Tables'),
+          bugsnag.addFeatureFlags(const [
+            FeatureFlag('demo-mode'),
+            FeatureFlag('sample-group', '123'),
+          ]),
+        ]);
+
         if (extraConfig?.contains("handled") == true) {
           await bugsnag.notify(
             Exception('Exception with attached info'),

--- a/features/fixtures/app/lib/scenarios/breadcrumbs_scenario.dart
+++ b/features/fixtures/app/lib/scenarios/breadcrumbs_scenario.dart
@@ -9,7 +9,7 @@ class BreadcrumbsScenario extends Scenario {
       endpoints: endpoints,
     );
 
-    await bugsnag.leaveBreadcrumb('Manual breadcrumb', metadata: {
+    await bugsnag.leaveBreadcrumb('Manual breadcrumb', metadata: const {
       'foo': 'bar',
       'object': {'test': 'hello'}
     });


### PR DESCRIPTION
## Goal
Remove the native configuration options from `attach` to clarify what it actually does.

## Design
Configuration changes are not strictly available during execution on the native layers, and were being emulated by simply invoking the appropriate setter / add methods, which could be confusing in a Hybrid app (which `attach` is designed for) where `attach` may be invoked any number of times over the app lifecycle.

## Testing
Modified existing tests to not include the native configuration options (as it would no longer compile)