### PR TITLE
Attempt project package detection if no projectPackages is specified

### DIFF
--- a/bugsnag_flutter/android/src/main/java/com/bugsnag/flutter/BugsnagFlutter.java
+++ b/bugsnag_flutter/android/src/main/java/com/bugsnag/flutter/BugsnagFlutter.java
@@ -193,6 +193,15 @@ class BugsnagFlutter {
             configuration.setProjectPackages(packagesSet);
         }
 
+        if (args.has("defaultProjectPackage")) {
+            // default to the Flutter app packge + the default Android package
+            Set<String> projectPackages = new HashSet<>();
+            projectPackages.add(args.getString("defaultProjectPackage"));
+            projectPackages.add(context.getPackageName());
+
+            configuration.setProjectPackages(projectPackages);
+        }
+
         if (args.has("versionCode")) {
             configuration.setVersionCode(args.getInt("versionCode"));
         }

--- a/features/start_bugsnag.feature
+++ b/features/start_bugsnag.feature
@@ -19,3 +19,7 @@ Feature: Start Bugsnag from Flutter
       | demo-mode    |         |
       | sample-group | 123     |
     And on Android, the event "app.versionCode" equals 4321
+
+    And on Android, the error payload field "events.0.projectPackages" is an array with 2 elements
+    And on Android, the event "projectPackages.0" equals "MazeRunner"
+    And on Android, the event "projectPackages.1" equals "com.bugsnag.flutter.test.app"


### PR DESCRIPTION
## Goal
Attempt to auto-detect the `projectPackages` when they are not specified.

## Design
If Bugsnag is started without a specified `projectPackages`, attempt to detect it by looking at the stack trace for the call-frame before `bugsnag` as this is most likely the application.

This approach will fail when:
- the application does not have debug info (`--split-debug-info`)
- Bugsnag is called from a library instead of the main application
- Bugsnag is started in the native layer

### iOS
The Cocoa notifier currently strips the `projectPackages` fields, which will stop the pipeline from correctly inferring `inProject` frames.

## Testing
Additional steps added to the `start_bugsnag` scenario to verify the configuration