### PR TITLE
[PLAT-8373] Add `projectPackages` support for iOS

### DIFF
--- a/features/project_packages.feature
+++ b/features/project_packages.feature
@@ -1,6 +1,5 @@
 Feature: projectPackages
 
-  @skip_ios
   Scenario: Sends projectPackages with events
     When I run "ProjectPackagesScenario"
     Then I wait to receive an error


### PR DESCRIPTION
## Goal

Allow `projectPackages` to be included in events sent through the Cocoa notifier.

## Changeset

Captures `projectPackages` at start and injects them into Cocoa events.

Swizzles the serialisation methods to add support for this new property, avoiding the need to modify and wait for a new release of bugsnag-cocoa.

## Testing

Verified functionality using existing E2E scenario.