### PR TITLE
Ensure a Session is open in bugsnag.start

### DIFF
--- a/bugsnag_flutter/lib/src/client.dart
+++ b/bugsnag_flutter/lib/src/client.dart
@@ -559,6 +559,10 @@ class Bugsnag extends Client with DelegateClient {
     client._onErrorCallbacks.addAll(onError);
     this.client = client;
 
+    if (autoTrackSessions) {
+      await resumeSession().onError((error, stackTrace) => true);
+    }
+
     _runWithErrorDetection(autoDetectErrors, () => runApp?.call());
   }
 

--- a/features/start_bugsnag.feature
+++ b/features/start_bugsnag.feature
@@ -10,6 +10,7 @@ Feature: Start Bugsnag from Flutter
     And the event "app.type" equals "test"
     And the event "app.version" equals "1.2.3"
     And the event "context" equals "awesome"
+    And the event "session.id" matches "^.+$"
     And the event "metaData.custom.foo" equals "bar"
     And the event "metaData.custom.password" equals "not redacted"
     And the event "metaData.custom.secret" equals "[REDACTED]"


### PR DESCRIPTION
## Goal
Ensure a session is open (if `autoTrackSessions` is enabled) in `bugsnag.start` before `runApp` is invoked. As Flutter starts should always have a session open, regardless of the platform state.

## Design
Android Sessions are determined by platform `Activity` callbacks. Any Flutter app using a `FlutterActivity` and a Dart-level `Bugsnag.start` will miss that callback (since the Android `Activity` is created & started before the Dart engine). This change ensures that Events can be associated with a session, regardless of the platform startup & session integration.

## Testing
New steps added to the `start_bugsnag` scenario