### PR TITLE
Ensure all date in the model are always UTC

### DIFF
--- a/bugsnag_flutter/lib/src/model/breadcrumbs.dart
+++ b/bugsnag_flutter/lib/src/model/breadcrumbs.dart
@@ -16,7 +16,7 @@ class BugsnagBreadcrumb {
 
   BugsnagBreadcrumb.fromJson(Map<String, dynamic> json)
       : message = json.safeGet('name'),
-        timestamp = DateTime.parse(json['timestamp'] as String),
+        timestamp = DateTime.parse(json['timestamp'] as String).toUtc(),
         type = BreadcrumbType.values.byName(json['type'] as String),
         metadata = json
             .safeGet<Map>('metaData')

--- a/bugsnag_flutter/lib/src/model/device.dart
+++ b/bugsnag_flutter/lib/src/model/device.dart
@@ -54,7 +54,9 @@ class DeviceWithState extends Device {
       : freeDisk = json.safeGet<num>('freeDisk')?.toInt(),
         freeMemory = json.safeGet<num>('freeMemory')?.toInt(),
         orientation = json.safeGet('orientation'),
-        time = json.safeGet<String>('time')?.let(DateTime.parse),
+        time = json
+            .safeGet<String>('time')
+            ?.let((time) => DateTime.parse(time).toUtc()),
         super.fromJson(json);
 
   @override
@@ -64,6 +66,6 @@ class DeviceWithState extends Device {
         if (freeDisk != null) 'freeDisk': freeDisk,
         if (freeMemory != null) 'freeMemory': freeMemory,
         if (orientation != null) 'orientation': orientation,
-        if (time != null) 'time': time!.toIso8601String(),
+        if (time != null) 'time': time!.toUtc().toIso8601String(),
       };
 }

--- a/bugsnag_flutter/lib/src/model/event.dart
+++ b/bugsnag_flutter/lib/src/model/event.dart
@@ -147,7 +147,7 @@ class _Session {
 
   _Session.fromJson(Map<String, dynamic> json)
       : id = json['id'] as String,
-        startedAt = DateTime.parse(json['startedAt'] as String),
+        startedAt = DateTime.parse(json['startedAt'] as String).toUtc(),
         handledCount =
             (json['events'] as Map?)?.safeGet<num>('handled')?.toInt() ?? 0,
         unhandledCount =
@@ -155,7 +155,7 @@ class _Session {
 
   dynamic toJson() => {
         'id': id,
-        'startedAt': startedAt.toIso8601String(),
+        'startedAt': startedAt.toUtc().toIso8601String(),
         'events': {
           'handled': handledCount,
           'unhandled': unhandledCount,

--- a/bugsnag_flutter/lib/src/model/session.dart
+++ b/bugsnag_flutter/lib/src/model/session.dart
@@ -7,12 +7,12 @@ class BugsnagSession {
 
   BugsnagSession.fromJson(Map<String, dynamic> json)
       : id = json['id'] as String,
-        startedAt = DateTime.parse(json['startedAt']),
+        startedAt = DateTime.parse(json['startedAt']).toUtc(),
         user = User.fromJson(json['user'] as Map<String, dynamic>);
 
   dynamic toJson() => {
         'id': id,
-        'startedAt': startedAt.toIso8601String(),
+        'startedAt': startedAt.toUtc().toIso8601String(),
         'user': user,
       };
 }

--- a/bugsnag_flutter/test/model/device_test.dart
+++ b/bugsnag_flutter/test/model/device_test.dart
@@ -112,6 +112,9 @@ void main() {
       expect(device.time, DateTime.utc(2022, 3, 3, 2, 15, 50, 405));
       expect(device.totalMemory, 7823929344);
 
+      // change the time to Local, toJson should convert it back
+      device.time = DateTime(2022, 3, 3, 2, 15, 50, 405);
+
       expect(device.toJson(), json);
     });
 


### PR DESCRIPTION
## Goal
Fix serialization issues when Dates are included in certain parts of the Event payload.

## Design
The Android layer expects all dates to be strictly formatted in UTC time, so ensure that any `DateTime` received or sent is always in UTC

## Testing
Updated `device_test` so that a local date -> utc conversion is checked