### PR TITLE
Fix metaData.flutter.buildID on Cocoa

### DIFF
--- a/bugsnag_flutter/ios/Classes/BugsnagFlutterPlugin.m
+++ b/bugsnag_flutter/ios/Classes/BugsnagFlutterPlugin.m
@@ -373,10 +373,12 @@ static NSString *NSStringOrNil(id value) {
     @synchronized (featureFlagStore) {
         event.featureFlagStore = [featureFlagStore copy];
     }
+
+    NSString *buildID = event.app.dsymUuid;
     
     for (BugsnagStackframe *frame in error.stacktrace) {
         if ([frame.type isEqualToString:@"dart"] && !frame.codeIdentifier) {
-            frame.codeIdentifier = event.app.dsymUuid;
+            frame.codeIdentifier = buildID;
         }
     }
     
@@ -387,6 +389,9 @@ static NSString *NSStringOrNil(id value) {
     NSDictionary *metadata = json[@"flutterMetadata"];
     if (metadata != nil) {
         [event addMetadata:metadata toSection:@"flutter"];
+        if (!metadata[@"buildID"]) {
+            [event addMetadata:buildID withKey:@"buildID" toSection:@"flutter"];
+        }
     }
     
     if ([json[@"deliver"] boolValue]) {

--- a/features/handled_exception.feature
+++ b/features/handled_exception.feature
@@ -13,6 +13,7 @@ Feature: bugsnag.notify
     * the "lineNumber" of stack frame 0 equals 10
     * on iOS, the "codeIdentifier" of stack frame 0 is not null
     * on iOS, the "type" of stack frame 0 equals "dart"
+    * on iOS, the event "metaData.flutter.buildID" is not null
     * the event "metaData.flutter.defaultRouteName" equals "/"
     * the event "metaData.flutter.initialLifecycleState" is not null
     * the event "metaData.flutter.lifecycleState" is not null
@@ -34,6 +35,7 @@ Feature: bugsnag.notify
     * on iOS, the "codeIdentifier" of stack frame 0 is not null
     * on iOS, the "type" of stack frame 0 equals "dart"
     * on iOS, the event "app.dsymUUIDs.0" is not null
+    * on iOS, the event "metaData.flutter.buildID" is not null
     * the event "metaData.flutter.defaultRouteName" equals "/"
     * the event "metaData.flutter.initialLifecycleState" is not null
     * the event "metaData.flutter.lifecycleState" is not null


### PR DESCRIPTION
## Changeset

Sets `buildID` from within the plugin, as the buildID is not available to the Dart / Flutter layer.

## Testing

Tested manually and amended E2E scenarios.