### PR TITLE
Align minimum iOS version with bugsnag-cocoa

### DIFF
--- a/bugsnag_flutter/ios/bugsnag_flutter.podspec
+++ b/bugsnag_flutter/ios/bugsnag_flutter.podspec
@@ -11,7 +11,7 @@ Bugsnag crash monitoring and reporting tool for Flutter apps
   s.source              = { :path => '.' }
   s.source_files        = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
-  s.platform            = :ios, '9.0'
+  s.platform            = :ios, '9.3'
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
 


### PR DESCRIPTION
Sets the minimum supported iOS version to match that of [bugsnag-cocoa](https://github.com/bugsnag/bugsnag-cocoa/blob/master/Bugsnag.podspec.json#L23)