### PR TITLE
Correctly identify obfuscated stack frames as `dart`

### DIFF
--- a/bugsnag_flutter/lib/src/bugsnag_stacktrace.dart
+++ b/bugsnag_flutter/lib/src/bugsnag_stacktrace.dart
@@ -100,6 +100,7 @@ BugsnagStacktrace? parseNativeStackTrace(String stackTrace) {
           loadAddress: '0x' + baseOffset.toRadixString(16),
           codeIdentifier: buildId,
           method: frame.method,
+          type: BugsnagErrorType.dart,
         ));
       }
     }

--- a/bugsnag_flutter/test/bugsnag_stacktrace_test.dart
+++ b/bugsnag_flutter/test/bugsnag_stacktrace_test.dart
@@ -1,3 +1,4 @@
+import 'package:bugsnag_flutter/bugsnag.dart';
 import 'package:bugsnag_flutter/src/bugsnag_stacktrace.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -22,6 +23,11 @@ void main() {
       expect(
         stacktrace.map((f) => f.method),
         everyElement('_kDartIsolateSnapshotInstructions'),
+      );
+
+      expect(
+        stacktrace.map((f) => f.type),
+        everyElement(BugsnagErrorType.dart),
       );
 
       expect(


### PR DESCRIPTION
## Goal
Correctly identify obfuscated stack frames as `dart` so that dependant code in other projects works as expected.

## Testing
Added to the existing obfuscated stack trace unit tests.