### PR TITLE
build: add publish step for pub-dev staging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ all: format build lint test
 clean:
 	cd packages/bugsnag_flutter && flutter clean --suppress-analytics
 	cd example && flutter clean --suppress-analytics
+	rm -rf staging
 
 build: aar example
 
@@ -14,6 +15,16 @@ ifeq ($(VERSION),)
 endif
 	sed -i '' "s/^version: .*/version: $(VERSION)/" packages/bugsnag_flutter/pubspec.yaml
 	sed -i '' "s/^  'version': .*/  'version': '$(VERSION)'/" packages/bugsnag_flutter/lib/src/client.dart
+
+publish: clean
+	mkdir staging
+	cd packages/bugsnag_flutter && cp -a . ../../staging/
+	rm -f staging/pubspec.lock
+	cp -r example staging/example
+	cp README.md staging/.
+	cp LICENSE staging/.
+	cp CHANGELOG.md staging/.
+	sed -i '' -e '1,2d' staging/CHANGELOG.md
 
 aar:
 	cd packages/bugsnag_flutter && flutter build aar --suppress-analytics

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Bugsnag error monitoring & reporting for Flutter apps
 
 [![Documentation](https://img.shields.io/badge/documentation-latest-blue.svg)](https://docs.bugsnag.com/platforms/flutter/)
+[![Build status](https://badge.buildkite.com/e5d6c82f7202bbfe7114be8b8cb245b447a29470cd9320658b.svg)](https://buildkite.com/bugsnag/bugsnag-flutter)
 
 Get comprehensive [Flutter error reports](https://www.bugsnag.com/platforms/flutter/) to quickly
 debug errors.

--- a/example/README.md
+++ b/example/README.md
@@ -1,6 +1,6 @@
 # Example Flutter application with Bugsnag
 
-Demonstrates how to use the bugsnag_flutter plugin.
+Demonstrates how to use the bugsnag_flutter package.
 
 ## Getting Started
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 
 import 'package:bugsnag_flutter/bugsnag.dart';
 import 'package:bugsnag_flutter/widgets.dart';
-import 'package:examples/native_crashes.dart';
+import 'package:bugsnag_example/native_crashes.dart';
 import 'package:flutter/material.dart';
 
 import 'bad_widget.dart';

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,5 +1,6 @@
-name: examples
-description: Demonstrates how to use the flutter plugin.
+name: bugsnag_example
+version: 1.0.0
+description: Demonstrates how to use the bugsnag_flutter package.
 
 # The following line prevents the package from being accidentally published to
 # pub.dev using `flutter pub publish`. This is preferred for private packages.

--- a/packages/bugsnag_flutter/pubspec.yaml
+++ b/packages/bugsnag_flutter/pubspec.yaml
@@ -2,12 +2,15 @@ name: bugsnag_flutter
 description: Bugsnag crash monitoring and reporting tool for Flutter apps
 version: 2.0.0-rc5
 homepage: https://www.bugsnag.com/
+documentation: https://docs.bugsnag.com/platforms/flutter/
+repository: https://github.com/bugsnag/bugsnag-flutter
+issue_tracker: https://github.com/bugsnag/bugsnag-flutter/issues
 
-publish_to: 'none' # Remove this line once we're ready for release
+#publish_to: 'none' # Remove this line once we're ready for release
 
 environment:
   sdk: ">=2.15.1 <3.0.0"
-  flutter: "2.0.0"
+  flutter: ">=2.0.0"
 
 dependencies:
   flutter:

--- a/packages/bugsnag_flutter/pubspec.yaml
+++ b/packages/bugsnag_flutter/pubspec.yaml
@@ -6,8 +6,6 @@ documentation: https://docs.bugsnag.com/platforms/flutter/
 repository: https://github.com/bugsnag/bugsnag-flutter
 issue_tracker: https://github.com/bugsnag/bugsnag-flutter/issues
 
-#publish_to: 'none' # Remove this line once we're ready for release
-
 environment:
   sdk: ">=2.15.1 <3.0.0"
   flutter: ">=2.0.0"


### PR DESCRIPTION
## Goal

Added a `publish` target that creates `/staging` directory with the correct structure and content for publishing to pub.dev.

Also added/tidied some content, such as details in pubspec.yml and added a build badge to the readme.

## Testing

This passes the validation you get when you run `dart pub publish --dry-run`.