### PR TITLE
Remove IDE / user directories during clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,11 @@ all: format build lint test
 
 clean:
 	cd packages/bugsnag_flutter && flutter clean --suppress-analytics
-	cd example && flutter clean --suppress-analytics
+	cd example && flutter clean --suppress-analytics && \
+			rm -rf .idea bugsnag_flutter_example.iml \
+			       ios/{Pods,.symlinks,Podfile.lock} \
+				   ios/{Runner.xcworkspace,Runner.xcodeproj,Runner.xcodeproj/project.xcworkspace}/xcuserdata \
+				   android/{.idea,.gradle,gradlew,gradlew.bat,local.properties,bugsnag_flutter_example_android.iml}
 	rm -rf staging
 
 build: aar example


### PR DESCRIPTION
## Goal
Remove IDE generated directories from `example` during a `clean` so that the staged Example app accurately reflects what can be published.

We should always publish from a clean checkout of the repository or (preferably) from a CI instance, but this adds an additional layer of safety.

## Testing
Manual testing