### PR TITLE
[PLAT-8425] Verify that UUID / codeIdentifier changes

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -18,6 +18,12 @@ steps:
     commands:
       - pod repo update
       - make example
+      # Verify that App.framework's UUID (and therefore our `codeIdentifier`) changes when Dart code is touched
+      - dwarfdump --arch=arm64 --uuid example/build/ios/iphoneos/Runner.app/Frameworks/App.framework/App | tee uuid_before
+      - sed -i '' -e 's/add_your_api_key_here/my_api_key/' example/lib/main.dart
+      - make example
+      - dwarfdump --arch=arm64 --uuid example/build/ios/iphoneos/Runner.app/Frameworks/App.framework/App | tee uuid_after
+      - test "$(cat uuid_before)" != "$(cat uuid_after)"
 
   #
   # iOS


### PR DESCRIPTION
## Goal

Check our assumption that `Frameworks/App.framework/App`'s UUID changes when Dart code changes, since we use that as the `codeIdentifier` to uniquely identify each build.

## Changeset

Rebuilds example app after changing one of the source files and checks that UUID changes.

## Testing

Tested on CI.