### PR TITLE
Improve default projectPackages detection

### DIFF
--- a/packages/bugsnag_flutter/lib/src/client.dart
+++ b/packages/bugsnag_flutter/lib/src/client.dart
@@ -595,8 +595,8 @@ class Bugsnag extends Client with DelegateClient {
   String? _findProjectPackage() {
     try {
       final frames = StackFrame.fromStackTrace(StackTrace.current);
-      final lastBugsnag =
-          frames.lastIndexWhere((f) => f.package.contains('bugsnag'));
+      final lastBugsnag = frames.lastIndexWhere((f) =>
+          f.packageScheme == 'package' && f.package == 'bugsnag_flutter');
 
       if (lastBugsnag != -1 && lastBugsnag < frames.length) {
         final package = frames[lastBugsnag + 1].package;

--- a/packages/bugsnag_flutter/test/bugsnag_test.dart
+++ b/packages/bugsnag_flutter/test/bugsnag_test.dart
@@ -48,5 +48,13 @@ void main() {
       expect(channel['createEvent'], hasLength(1));
       expect(channel['createEvent'][0]['deliver'], isTrue);
     });
+
+    test('default projectPackages', () async {
+      channel.results['start'] = true;
+      await bugsnag.start();
+
+      // file "packages" are <unknown>
+      expect(channel['start'][0]['defaultProjectPackage'], equals('<unknown>'));
+    });
   });
 }


### PR DESCRIPTION
## Goal
Improve the detection of `projectPackages` so that packages containing the word `bugsnag` are not accidentally seen as "Bugsnag" stack frames.

## Testing
A new unit test was added