### PR TITLE
Split `unhandledExceptions` into Java and Dart errors

### DIFF
--- a/features/detect_enabled_errors.feature
+++ b/features/detect_enabled_errors.feature
@@ -1,0 +1,23 @@
+Feature: Auto Detect Enabled Errors
+
+  @skip_ios
+  Scenario: Native errors can be disabled separately to Dart errors
+    Given I configure the app to run in the "detectDartExceptions" state
+    When I run "DetectEnabledErrorsScenario" and relaunch the crashed app
+    And I configure Bugsnag for "DetectEnabledErrorsScenario"
+    * I wait to receive an error
+    Then the error payload field "events" is an array with 1 elements
+    * the event "unhandled" is true
+    * the exception "errorClass" equals "_Exception"
+    * the exception "message" equals "Exception from Dart"
+
+  @skip_ios
+  Scenario: Dart errors can be disabled separately to JVM errors
+    Given I configure the app to run in the "detectJvmExceptions" state
+    When I run "DetectEnabledErrorsScenario" and relaunch the crashed app
+    And I configure Bugsnag for "DetectEnabledErrorsScenario"
+    * I wait to receive an error
+    Then the error payload field "events" is an array with 1 elements
+    * the event "unhandled" is true
+    * the exception "errorClass" equals "java.lang.RuntimeException"
+    * the exception "message" equals "crash from Java"

--- a/features/fixtures/app/lib/scenarios/detect_enabled_errors.dart
+++ b/features/fixtures/app/lib/scenarios/detect_enabled_errors.dart
@@ -1,0 +1,30 @@
+import 'dart:async';
+
+import 'package:bugsnag_flutter/bugsnag.dart';
+
+import '../channels.dart';
+import 'scenario.dart';
+
+class DetectEnabledErrorsScenario extends Scenario {
+  @override
+  Future<void> run() async {
+    await bugsnag.start(
+      enabledErrorTypes: EnabledErrorTypes(
+        unhandledDartExceptions:
+            extraConfig?.contains('detectDartExceptions') == true,
+        unhandledJvmExceptions:
+            extraConfig?.contains('detectJvmExceptions') == true,
+      ),
+      endpoints: endpoints,
+      runApp: () {
+        Zone.root.run(_delayedNativeException);
+        throw Exception('Exception from Dart');
+      },
+    );
+  }
+
+  Future<void> _delayedNativeException() async {
+    await Future.delayed(const Duration(seconds: 1));
+    await MazeRunnerChannels.runScenario('NativeCrashScenario');
+  }
+}

--- a/features/fixtures/app/lib/scenarios/scenarios.dart
+++ b/features/fixtures/app/lib/scenarios/scenarios.dart
@@ -1,6 +1,7 @@
 import 'app_hang_scenario.dart';
 import 'attach_bugsnag_scenario.dart';
 import 'breadcrumbs_scenario.dart';
+import 'detect_enabled_errors.dart';
 import 'discard_classes_scenario.dart';
 import 'error_boundary_scenario.dart';
 import 'error_handler_scenario.dart';
@@ -47,4 +48,5 @@ const List<ScenarioInfo<Scenario>> scenarios = [
   ScenarioInfo('StartBugsnagScenario', StartBugsnagScenario.new),
   ScenarioInfo('ThrowExceptionScenario', ThrowExceptionScenario.new),
   ScenarioInfo('UnhandledExceptionScenario', UnhandledExceptionScenario.new),
+  ScenarioInfo('DetectEnabledErrorsScenario', DetectEnabledErrorsScenario.new),
 ];

--- a/packages/bugsnag_flutter/lib/src/client.dart
+++ b/packages/bugsnag_flutter/lib/src/client.dart
@@ -504,10 +504,13 @@ class Bugsnag extends Client with DelegateClient {
     Directory? persistenceDirectory,
     int? versionCode,
   }) async {
+    final detectDartErrors =
+        autoDetectErrors && enabledErrorTypes.unhandledDartExceptions;
+
     // guarding WidgetsFlutterBinding.ensureInitialized() catches
     // async errors within the Flutter app
     _runWithErrorDetection(
-      autoDetectErrors,
+      detectDartErrors,
       () => WidgetsFlutterBinding.ensureInitialized(),
     );
 
@@ -555,7 +558,7 @@ class Bugsnag extends Client with DelegateClient {
       if (versionCode != null) 'versionCode': versionCode,
     });
 
-    final client = ChannelClient(autoDetectErrors);
+    final client = ChannelClient(detectDartErrors);
     client._onErrorCallbacks.addAll(onError);
     this.client = client;
 
@@ -563,7 +566,7 @@ class Bugsnag extends Client with DelegateClient {
       await resumeSession().onError((error, stackTrace) => true);
     }
 
-    _runWithErrorDetection(autoDetectErrors, () => runApp?.call());
+    _runWithErrorDetection(detectDartErrors, () => runApp?.call());
   }
 
   void _runWithErrorDetection(

--- a/packages/bugsnag_flutter/lib/src/config.dart
+++ b/packages/bugsnag_flutter/lib/src/config.dart
@@ -1,5 +1,6 @@
 class EnabledErrorTypes {
-  final bool unhandledExceptions;
+  final bool unhandledJvmExceptions;
+  final bool unhandledDartExceptions;
   final bool crashes;
   final bool ooms;
   final bool thermalKills;
@@ -7,7 +8,8 @@ class EnabledErrorTypes {
   final bool anrs;
 
   const EnabledErrorTypes({
-    this.unhandledExceptions = true,
+    this.unhandledJvmExceptions = true,
+    this.unhandledDartExceptions = true,
     this.crashes = true,
     this.ooms = true,
     this.thermalKills = true,
@@ -16,7 +18,7 @@ class EnabledErrorTypes {
   });
 
   dynamic toJson() => {
-        'unhandledExceptions': unhandledExceptions,
+        'unhandledExceptions': unhandledJvmExceptions,
         'crashes': crashes,
         'ooms': ooms,
         'thermalKills': thermalKills,


### PR DESCRIPTION
## Goal
Distinguish unhandled exceptions that happen on the JVM/Android Runtime (on Android) and those that happen in Dart.

## Testing
New end to end test scenario