### PR TITLE
Use a more flexible `ProjectPackages` type

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,8 +1,8 @@
 import 'dart:async';
 
+import 'package:bugsnag_example/native_crashes.dart';
 import 'package:bugsnag_flutter/bugsnag.dart';
 import 'package:bugsnag_flutter/widgets.dart';
-import 'package:bugsnag_example/native_crashes.dart';
 import 'package:flutter/material.dart';
 
 import 'bad_widget.dart';
@@ -13,7 +13,7 @@ void main() async => bugsnag.start(
       // Find your API key in the settings menu of your Bugsnag dashboard
       apiKey: 'add_your_api_key_here',
       // Specify in-project packages if you have multiple or are splitting debug info in your build (--split-debug-info)
-      projectPackages: const {'bugsnag_example'},
+      projectPackages: const ProjectPackages.only({'bugsnag_example'}),
       // onError callbacks can be used to modify or reject certain events
       onError: [
         (event) {

--- a/features/fixtures/app/lib/scenarios/project_packages_scenario.dart
+++ b/features/fixtures/app/lib/scenarios/project_packages_scenario.dart
@@ -5,7 +5,10 @@ import 'scenario.dart';
 class ProjectPackagesScenario extends Scenario {
   @override
   Future<void> run() async {
-    await bugsnag.start(endpoints: endpoints, projectPackages: {'app'});
+    await bugsnag.start(
+      endpoints: endpoints,
+      projectPackages: ProjectPackages.withPlatformDefaults(const {'app'}),
+    );
     await bugsnag.notify(Exception(), null);
   }
 }

--- a/features/project_packages.feature
+++ b/features/project_packages.feature
@@ -6,5 +6,7 @@ Feature: projectPackages
     And the error is valid for the error reporting API version "4.0" for the "Flutter Bugsnag Notifier" notifier
     And the exception "errorClass" equals "_Exception"
     And the event "severity" equals "warning"
-    And the error payload field "events.0.projectPackages" is an array with 1 elements
+    And on iOS, the error payload field "events.0.projectPackages" is an array with 1 elements
+    And on Android, the error payload field "events.0.projectPackages" is an array with 2 elements
     And the event "projectPackages.0" equals "app"
+    And on Android, the event "projectPackages.1" equals "com.bugsnag.flutter.test.app"

--- a/packages/bugsnag_flutter/android/src/main/java/com/bugsnag/flutter/BugsnagFlutter.java
+++ b/packages/bugsnag_flutter/android/src/main/java/com/bugsnag/flutter/BugsnagFlutter.java
@@ -28,6 +28,7 @@ import org.json.JSONObject;
 
 import java.io.File;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -182,24 +183,21 @@ class BugsnagFlutter {
         }
 
         if (args.has("projectPackages")) {
-            JSONArray projectPackages = args.optJSONArray("projectPackages");
-            final int packageCount = projectPackages.length();
-            Set<String> packagesSet = new HashSet<>(packageCount);
+            JSONObject projectPackages = args.optJSONObject("projectPackages");
+
+            JSONArray packageNames = projectPackages.getJSONArray("packageNames");
+            final int packageCount = packageNames.length();
+            Set<String> packagesSet = new LinkedHashSet<>(packageCount);
 
             for (int index = 0; index < packageCount; index++) {
-                packagesSet.add(projectPackages.getString(index));
+                packagesSet.add(packageNames.getString(index));
+            }
+
+            if (projectPackages.optBoolean("includeDefaults")) {
+                packagesSet.add(context.getPackageName());
             }
 
             configuration.setProjectPackages(packagesSet);
-        }
-
-        if (args.has("defaultProjectPackage")) {
-            // default to the Flutter app package + the default Android package
-            Set<String> projectPackages = new HashSet<>();
-            projectPackages.add(args.getString("defaultProjectPackage"));
-            projectPackages.add(context.getPackageName());
-
-            configuration.setProjectPackages(projectPackages);
         }
 
         if (args.has("versionCode")) {

--- a/packages/bugsnag_flutter/ios/Classes/BugsnagFlutterPlugin.m
+++ b/packages/bugsnag_flutter/ios/Classes/BugsnagFlutterPlugin.m
@@ -362,10 +362,9 @@ static NSString *NSStringOrNil(id value) {
                                                                url:notifier[@"url"]
                                                       dependencies:@[[[BugsnagNotifier alloc] init]]];
     
-    NSString *defaultProjectPackage = arguments[@"defaultProjectPackage"];
-    self.projectPackages = arguments[@"projectPackages"];
-    if (!self.projectPackages && defaultProjectPackage) {
-        self.projectPackages = @[defaultProjectPackage];
+    NSDictionary *projectPackages = arguments[@"projectPackages"];
+    if ([projectPackages isKindOfClass:[NSDictionary class]]) {
+        self.projectPackages = projectPackages[@"packageNames"];
     }
     
     [Bugsnag startWithConfiguration:configuration];

--- a/packages/bugsnag_flutter/lib/src/config.dart
+++ b/packages/bugsnag_flutter/lib/src/config.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+
 class EnabledErrorTypes {
   final bool unhandledJvmExceptions;
   final bool unhandledDartExceptions;
@@ -47,6 +49,76 @@ class EndpointConfiguration {
   /// Default Bugsnag `EndpointConfiguration`
   static const EndpointConfiguration bugsnag = EndpointConfiguration(
       'https://notify.bugsnag.com', 'https://sessions.bugsnag.com');
+}
+
+/// In order to determine where a crash happens Bugsnag needs to know which
+/// packages you consider to be part of your app (as opposed to a library).
+///
+/// [By default](ProjectPackages.detected) this is set according to the
+/// underlying platform (iOS or Android) and an attempt is made to discover
+/// the Dart package your application uses. This detection *will not work* if
+/// you build using `--split-debug-info`.
+///
+/// See also:
+/// - [Bugsnag.start]
+/// - [ProjectPackages.detected]
+class ProjectPackages {
+  final bool _includeDefaults;
+  final Set<String> _packageNames;
+
+  const ProjectPackages._internal(this._packageNames, this._includeDefaults);
+
+  /// Specify the exact list of packages to consider as part of the project.
+  /// This should include packages from both Dart and any Java packages
+  /// your application uses on Android.
+  ///
+  /// See also:
+  /// - [withPlatformDefaults]
+  const ProjectPackages.only(Set<String> packageNames)
+      : this._internal(packageNames, false);
+
+  /// Combine the given set of `packageNames` with whatever package names are
+  /// appropriate on the current platform. This is useful when you are using
+  /// `--split-debug-info` and only want to specify your Dart packages in
+  /// [Bugsnag.start].
+  ///
+  /// See also:
+  /// - [detected]
+  /// - [Android Configuration.projectPackages](https://docs.bugsnag.com/platforms/android/configuration-options/#projectpackages)
+  ProjectPackages.withPlatformDefaults(Set<String> packageNames)
+      : this._internal(packageNames, true);
+
+  /// Attempt to automatically detect all of the packages used by this
+  /// application. This detection *will not work* if
+  /// you build using `--split-debug-info`.
+  ///
+  /// When using `--split-debug-info` you should use [withPlatformDefaults] or
+  /// [only] to specify your `projectPackages` manually.
+  ProjectPackages.detected() : this._internal(_findProjectPackages(), true);
+
+  dynamic toJson() => <String, dynamic>{
+        'includeDefaults': _includeDefaults,
+        'packageNames': List.from(_packageNames),
+      };
+
+  static Set<String> _findProjectPackages() {
+    try {
+      final frames = StackFrame.fromStackTrace(StackTrace.current);
+      final lastBugsnag = frames.lastIndexWhere((f) =>
+          f.packageScheme == 'package' && f.package == 'bugsnag_flutter');
+
+      if (lastBugsnag != -1 && lastBugsnag < frames.length) {
+        final package = frames[lastBugsnag + 1].package;
+        if (package.isNotEmpty && package != 'null') {
+          return {package};
+        }
+      }
+    } catch (e) {
+      // deliberately ignored, we return null
+    }
+
+    return const <String>{};
+  }
 }
 
 /// Controls whether we should capture and serialize the state of all threads

--- a/packages/bugsnag_flutter/test/bugsnag_test.dart
+++ b/packages/bugsnag_flutter/test/bugsnag_test.dart
@@ -54,7 +54,13 @@ void main() {
       await bugsnag.start();
 
       // file "packages" are <unknown>
-      expect(channel['start'][0]['defaultProjectPackage'], equals('<unknown>'));
+      expect(
+        channel['start'][0]['projectPackages']['packageNames'][0],
+        equals('<unknown>'),
+      );
+
+      // we should request platform default-packages by default
+      expect(channel['start'][0]['projectPackages']['includeDefaults'], isTrue);
     });
   });
 }


### PR DESCRIPTION
## Goal
Provide a more flexible way of specifying `projectPackages` using a custom wrapper type.

## Design
In order to allow for `projectPackages` to be declared in Dart but still possibly include platform-specific packages (currently just the Android application package) we add a new `ProjectPackages` class similar to the existing `EnabledErrorTypes` and `EndpointConfiguration`.

The new class also takes care of the Dart package-detection when no `projectPackages` are specified in `Bugsnag.start`.

## Testing
Modified existing unit test and end2end scenario