### PR TITLE
Remove ReactNative-specific `codeBundleId` from App

### DIFF
--- a/packages/bugsnag_flutter/lib/src/model/app.dart
+++ b/packages/bugsnag_flutter/lib/src/model/app.dart
@@ -18,8 +18,6 @@ class App {
   /// Equivalent to `versionCode` on Android.
   String? bundleVersion;
 
-  String? codeBundleId;
-
   /// iOS only: Unique identifier for the debug symbols file corresponding to
   /// the application
   List<String>? dsymUuids;
@@ -44,7 +42,6 @@ class App {
       : binaryArch = json.safeGet('binaryArch'),
         buildUUID = json.safeGet('buildUUID'),
         bundleVersion = json.safeGet('bundleVersion'),
-        codeBundleId = json.safeGet('codeBundleId'),
         dsymUuids = json
             .safeGet<List>('dsymUUIDs')
             ?.cast<String>()
@@ -59,7 +56,6 @@ class App {
         if (binaryArch != null) 'binaryArch': binaryArch,
         if (buildUUID != null) 'buildUUID': buildUUID,
         if (bundleVersion != null) 'bundleVersion': bundleVersion,
-        if (codeBundleId != null) 'codeBundleId': codeBundleId,
         if (dsymUuids != null) 'dsymUUIDs': dsymUuids,
         if (id != null) 'id': id,
         if (releaseStage != null) 'releaseStage': releaseStage,


### PR DESCRIPTION
## Goal
`App.codeBundleId` is only applicable to ReactNative applications (which the Flutter layer cannot receive or process events from as things stand). This PR removes that field.


## Testing
Relied on existing tests.