### PR TITLE
`withPlatformDefaults` should be `const`

### DIFF
--- a/packages/bugsnag_flutter/lib/src/config.dart
+++ b/packages/bugsnag_flutter/lib/src/config.dart
@@ -85,7 +85,7 @@ class ProjectPackages {
   /// See also:
   /// - [detected]
   /// - [Android Configuration.projectPackages](https://docs.bugsnag.com/platforms/android/configuration-options/#projectpackages)
-  ProjectPackages.withPlatformDefaults(Set<String> packageNames)
+  const ProjectPackages.withPlatformDefaults(Set<String> packageNames)
       : this._internal(packageNames, true);
 
   /// Attempt to automatically detect all of the packages used by this


### PR DESCRIPTION
## Goal
`ProjectPackages.withPlatformDefaults` should have been `const` as it has a fixed compile-time value.

## Testing
No testing required