### PR TITLE
Replace `ProjectPackages.withPlatformDefaults` with `withDefaults`

### DIFF
--- a/features/fixtures/app/lib/scenarios/project_packages_scenario.dart
+++ b/features/fixtures/app/lib/scenarios/project_packages_scenario.dart
@@ -7,7 +7,7 @@ class ProjectPackagesScenario extends Scenario {
   Future<void> run() async {
     await bugsnag.start(
       endpoints: endpoints,
-      projectPackages: ProjectPackages.withPlatformDefaults(const {'app'}),
+      projectPackages: const ProjectPackages.withDefaults({'test_package'}),
     );
     await bugsnag.notify(Exception(), null);
   }

--- a/features/project_packages.feature
+++ b/features/project_packages.feature
@@ -6,7 +6,8 @@ Feature: projectPackages
     And the error is valid for the error reporting API version "4.0" for the "Flutter Bugsnag Notifier" notifier
     And the exception "errorClass" equals "_Exception"
     And the event "severity" equals "warning"
-    And on iOS, the error payload field "events.0.projectPackages" is an array with 1 elements
-    And on Android, the error payload field "events.0.projectPackages" is an array with 2 elements
-    And the event "projectPackages.0" equals "app"
-    And on Android, the event "projectPackages.1" equals "com.bugsnag.flutter.test.app"
+    And on iOS, the error payload field "events.0.projectPackages" is an array with 2 elements
+    And on Android, the error payload field "events.0.projectPackages" is an array with 3 elements
+    And the event "projectPackages.0" equals "test_package"
+    And the event "projectPackages.1" equals "MazeRunner"
+    And on Android, the event "projectPackages.2" equals "com.bugsnag.flutter.test.app"

--- a/packages/bugsnag_flutter/lib/bugsnag.dart
+++ b/packages/bugsnag_flutter/lib/bugsnag.dart
@@ -1,6 +1,6 @@
 export 'src/breadcrumbs/navigation.dart';
 export 'src/callbacks.dart' show OnErrorCallback;
-export 'src/client.dart' show bugsnag, Client, Bugsnag;
+export 'src/client.dart' show bugsnag, Client, Bugsnag, ProjectPackages;
 export 'src/config.dart';
 export 'src/helpers.dart';
 export 'src/last_run_info.dart';

--- a/packages/bugsnag_flutter/lib/src/config.dart
+++ b/packages/bugsnag_flutter/lib/src/config.dart
@@ -1,5 +1,3 @@
-import 'package:flutter/foundation.dart';
-
 class EnabledErrorTypes {
   final bool unhandledJvmExceptions;
   final bool unhandledDartExceptions;
@@ -49,76 +47,6 @@ class EndpointConfiguration {
   /// Default Bugsnag `EndpointConfiguration`
   static const EndpointConfiguration bugsnag = EndpointConfiguration(
       'https://notify.bugsnag.com', 'https://sessions.bugsnag.com');
-}
-
-/// In order to determine where a crash happens Bugsnag needs to know which
-/// packages you consider to be part of your app (as opposed to a library).
-///
-/// [By default](ProjectPackages.detected) this is set according to the
-/// underlying platform (iOS or Android) and an attempt is made to discover
-/// the Dart package your application uses. This detection *will not work* if
-/// you build using `--split-debug-info`.
-///
-/// See also:
-/// - [Bugsnag.start]
-/// - [ProjectPackages.detected]
-class ProjectPackages {
-  final bool _includeDefaults;
-  final Set<String> _packageNames;
-
-  const ProjectPackages._internal(this._packageNames, this._includeDefaults);
-
-  /// Specify the exact list of packages to consider as part of the project.
-  /// This should include packages from both Dart and any Java packages
-  /// your application uses on Android.
-  ///
-  /// See also:
-  /// - [withPlatformDefaults]
-  const ProjectPackages.only(Set<String> packageNames)
-      : this._internal(packageNames, false);
-
-  /// Combine the given set of `packageNames` with whatever package names are
-  /// appropriate on the current platform. This is useful when you are using
-  /// `--split-debug-info` and only want to specify your Dart packages in
-  /// [Bugsnag.start].
-  ///
-  /// See also:
-  /// - [detected]
-  /// - [Android Configuration.projectPackages](https://docs.bugsnag.com/platforms/android/configuration-options/#projectpackages)
-  const ProjectPackages.withPlatformDefaults(Set<String> packageNames)
-      : this._internal(packageNames, true);
-
-  /// Attempt to automatically detect all of the packages used by this
-  /// application. This detection *will not work* if
-  /// you build using `--split-debug-info`.
-  ///
-  /// When using `--split-debug-info` you should use [withPlatformDefaults] or
-  /// [only] to specify your `projectPackages` manually.
-  ProjectPackages.detected() : this._internal(_findProjectPackages(), true);
-
-  dynamic toJson() => <String, dynamic>{
-        'includeDefaults': _includeDefaults,
-        'packageNames': List.from(_packageNames),
-      };
-
-  static Set<String> _findProjectPackages() {
-    try {
-      final frames = StackFrame.fromStackTrace(StackTrace.current);
-      final lastBugsnag = frames.lastIndexWhere((f) =>
-          f.packageScheme == 'package' && f.package == 'bugsnag_flutter');
-
-      if (lastBugsnag != -1 && lastBugsnag < frames.length) {
-        final package = frames[lastBugsnag + 1].package;
-        if (package.isNotEmpty && package != 'null') {
-          return {package};
-        }
-      }
-    } catch (e) {
-      // deliberately ignored, we return null
-    }
-
-    return const <String>{};
-  }
 }
 
 /// Controls whether we should capture and serialize the state of all threads

--- a/packages/bugsnag_flutter/test/bugsnag_test.dart
+++ b/packages/bugsnag_flutter/test/bugsnag_test.dart
@@ -55,8 +55,8 @@ void main() {
 
       // file "packages" are <unknown>
       expect(
-        channel['start'][0]['projectPackages']['packageNames'][0],
-        equals('<unknown>'),
+        channel['start'][0]['projectPackages']['packageNames'],
+        equals(const ['<unknown>']),
       );
 
       // we should request platform default-packages by default

--- a/packages/bugsnag_flutter/test/project_packages_test.dart
+++ b/packages/bugsnag_flutter/test/project_packages_test.dart
@@ -1,0 +1,30 @@
+import 'package:bugsnag_flutter/bugsnag.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('ProjectPackages', () {
+    test('withDefaults', () {
+      const testPackages = ProjectPackages.withDefaults({'my_package_name'});
+
+      expect(
+        testPackages.toJson(),
+        equals({
+          'includeDefaults': true,
+          'packageNames': ['my_package_name'],
+        }),
+      );
+    });
+
+    test('only', () {
+      const testPackages = ProjectPackages.only({'my_package_name'});
+
+      expect(
+        testPackages.toJson(),
+        equals({
+          'includeDefaults': false,
+          'packageNames': ['my_package_name'],
+        }),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Goal
Remove the confusing `withPlatformDefaults` and introduce a simpler `ProjectPackages.withDefaults` which includes the default Android & Dart packages.

## Testing
New unit tests to cover `ProjectPackages`