### PR TITLE
Fix iOS symbolication in presence of onError

### DIFF
--- a/features/fixtures/app/lib/scenarios/on_error_scenario.dart
+++ b/features/fixtures/app/lib/scenarios/on_error_scenario.dart
@@ -1,0 +1,21 @@
+import 'package:bugsnag_flutter/bugsnag.dart';
+
+import 'scenario.dart';
+
+class OnErrorScenario extends Scenario {
+  @override
+  Future<void> run() => bugsnag.start(
+        endpoints: endpoints,
+        onError: [
+          (event) => event.errors.first.message != 'Ignored',
+          (event) {
+            event.errors.first.message = 'Not ignored';
+            return true;
+          },
+        ],
+        runApp: () async {
+          await bugsnag.notify(Exception('Ignored'), StackTrace.current);
+          await bugsnag.notify(Exception('Test'), StackTrace.current);
+        },
+      );
+}

--- a/features/fixtures/app/lib/scenarios/scenarios.dart
+++ b/features/fixtures/app/lib/scenarios/scenarios.dart
@@ -13,6 +13,7 @@ import 'manual_sessions_scenario.dart';
 import 'metadata_scenario.dart';
 import 'native_crash_scenario.dart';
 import 'navigation_breadcrumbs_scenario.dart';
+import 'on_error_scenario.dart';
 import 'project_packages_scenario.dart';
 import 'release_stage_scenario.dart';
 import 'scenario.dart';
@@ -32,6 +33,7 @@ const List<ScenarioInfo<Scenario>> scenarios = [
   ScenarioInfo('AppHangScenario', AppHangScenario.new),
   ScenarioInfo('AttachBugsnagScenario', AttachBugsnagScenario.new),
   ScenarioInfo('BreadcrumbsScenario', BreadcrumbsScenario.new),
+  ScenarioInfo('DetectEnabledErrorsScenario', DetectEnabledErrorsScenario.new),
   ScenarioInfo('DiscardClassesScenario', DiscardClassesScenario.new),
   ScenarioInfo('ErrorBoundaryWidgetScenario', ErrorBoundaryWidgetScenario.new),
   ScenarioInfo('ErrorHandlerScenario', ErrorHandlerScenario.new),
@@ -43,10 +45,10 @@ const List<ScenarioInfo<Scenario>> scenarios = [
   ScenarioInfo('MetadataScenario', MetadataScenario.new),
   ScenarioInfo('NativeCrashScenario', NativeCrashScenario.new),
   ScenarioInfo('NavigatorBreadcrumbScenario', NavigatorBreadcrumbScenario.new),
+  ScenarioInfo('OnErrorScenario', OnErrorScenario.new),
   ScenarioInfo('ProjectPackagesScenario', ProjectPackagesScenario.new),
   ScenarioInfo('ReleaseStageScenario', ReleaseStageScenario.new),
   ScenarioInfo('StartBugsnagScenario', StartBugsnagScenario.new),
   ScenarioInfo('ThrowExceptionScenario', ThrowExceptionScenario.new),
   ScenarioInfo('UnhandledExceptionScenario', UnhandledExceptionScenario.new),
-  ScenarioInfo('DetectEnabledErrorsScenario', DetectEnabledErrorsScenario.new),
 ];

--- a/features/on_error.feature
+++ b/features/on_error.feature
@@ -1,0 +1,7 @@
+Feature: OnError callbacks
+
+  Scenario: Filter and modify events in OnError
+    Given I run "OnErrorScenario"
+    And I wait to receive an error
+    Then the exception "message" equals "Not ignored"
+    And on iOS, the event "threads.0.stacktrace.0.symbolAddress" is not null

--- a/packages/bugsnag_flutter/ios/Classes/BugsnagFlutterPlugin.m
+++ b/packages/bugsnag_flutter/ios/Classes/BugsnagFlutterPlugin.m
@@ -444,6 +444,8 @@ static NSString *NSStringOrNil(id value) {
         [client notifyInternal:event block:nil];
         return nil;
     } else {
+        // A BugsnagStackframe initialized from JSON won't symbolicate, so do it now.
+        [event symbolicateIfNeeded];
         return [event toJsonWithRedactedKeys:nil];
     }
 }


### PR DESCRIPTION
## Goal

Fix unsymbolicated stack frames on iOS when an `onError:` callback is configured.

## Changeset

Symbolicates stack frames before serializing to JSON.

## Testing

Adds an E2E scenario that replicated the issue and verifies the fix.