### PR TITLE
Ignore lint warnings for `SchedulerBinding.instance` change

### DIFF
--- a/packages/bugsnag_flutter/lib/src/client.dart
+++ b/packages/bugsnag_flutter/lib/src/client.dart
@@ -524,6 +524,8 @@ class ChannelClient implements Client {
     final errorInfo = details?.informationCollector?.call() ?? [];
     final errorContext = details?.context?.toDescription();
     final errorLibrary = details?.library;
+    // SchedulerBinding.instance is nullable in Flutter <3.0.0
+    // ignore: invalid_null_aware_operator
     final lifecycleState = SchedulerBinding.instance?.lifecycleState.toString();
     final metadata = {
       if (buildID != null) 'buildID': buildID,


### PR DESCRIPTION
## Goal
Avoid lint warnings around `SchedulerBinding.instance` which has changed from being nullable to non-null in Flutter 3.0.0

## Testing
Manually checked linter rules