### PR TITLE
[PLAT-8521] Avoid name clashes

### DIFF
--- a/features/fixtures/app/lib/scenarios/last_run_info_scenario.dart
+++ b/features/fixtures/app/lib/scenarios/last_run_info_scenario.dart
@@ -17,7 +17,7 @@ class LastRunInfoScenario extends Scenario {
       Exception('After launch'),
       null,
       callback: (event) async {
-        final lastRunInfo = await bugsnag.getLastRunInfo() as LastRunInfo;
+        final lastRunInfo = (await bugsnag.getLastRunInfo())!;
         event.addMetadata('lastRunInfo', {
           'consecutiveLaunchCrashes': lastRunInfo.consecutiveLaunchCrashes,
           'crashed': lastRunInfo.crashed,

--- a/features/fixtures/app/lib/scenarios/on_error_scenario.dart
+++ b/features/fixtures/app/lib/scenarios/on_error_scenario.dart
@@ -9,6 +9,8 @@ class OnErrorScenario extends Scenario {
         onError: [
           (event) => event.errors.first.message != 'Ignored',
           (event) {
+            event.app.id = 'app_id';
+            event.device.id = 'device_id';
             event.errors.first.message = 'Not ignored';
             return true;
           },

--- a/features/fixtures/app/lib/scenarios/start_bugsnag_scenario.dart
+++ b/features/fixtures/app/lib/scenarios/start_bugsnag_scenario.dart
@@ -11,7 +11,7 @@ class StartBugsnagScenario extends Scenario {
       appVersion: '1.2.3',
       versionCode: 4321,
       context: 'awesome',
-      user: User(
+      user: BugsnagUser(
         id: '123',
         name: 'From Config',
       ),

--- a/features/on_error.feature
+++ b/features/on_error.feature
@@ -4,4 +4,6 @@ Feature: OnError callbacks
     Given I run "OnErrorScenario"
     And I wait to receive an error
     Then the exception "message" equals "Not ignored"
+    And the event "app.id" equals "app_id"
+    And the event "device.id" equals "device_id"
     And on iOS, the event "threads.0.stacktrace.0.symbolAddress" is not null

--- a/packages/bugsnag_flutter/lib/bugsnag_flutter.dart
+++ b/packages/bugsnag_flutter/lib/bugsnag_flutter.dart
@@ -3,5 +3,5 @@ export 'src/callbacks.dart' show OnErrorCallback;
 export 'src/client.dart' show bugsnag, Client, Bugsnag, ProjectPackages;
 export 'src/config.dart';
 export 'src/helpers.dart';
-export 'src/last_run_info.dart';
-export 'src/model.dart';
+export 'src/model/breadcrumbs.dart';
+export 'src/model/feature_flags.dart';

--- a/packages/bugsnag_flutter/lib/bugsnag_flutter.dart
+++ b/packages/bugsnag_flutter/lib/bugsnag_flutter.dart
@@ -5,3 +5,4 @@ export 'src/config.dart';
 export 'src/helpers.dart';
 export 'src/model/breadcrumbs.dart';
 export 'src/model/feature_flags.dart';
+export 'src/model/user.dart';

--- a/packages/bugsnag_flutter/lib/src/bugsnag_stacktrace.dart
+++ b/packages/bugsnag_flutter/lib/src/bugsnag_stacktrace.dart
@@ -1,5 +1,6 @@
-import 'package:bugsnag_flutter/bugsnag_flutter.dart';
 import 'package:flutter/foundation.dart';
+
+import 'model.dart';
 
 // This file is heavily based on:
 // https://github.com/dart-lang/sdk/blob/main/pkg/native_stack_traces/lib/src/convert.dart

--- a/packages/bugsnag_flutter/lib/src/client.dart
+++ b/packages/bugsnag_flutter/lib/src/client.dart
@@ -29,7 +29,7 @@ abstract class Client {
   Future<void> setUser({String? id, String? email, String? name});
 
   /// Returns the currently set User information.
-  Future<User> getUser();
+  Future<BugsnagUser> getUser();
 
   /// Bugsnag uses the concept of “contexts” to help display and group your
   /// errors. The context represents what was happening in your application
@@ -257,7 +257,7 @@ class DelegateClient implements Client {
       client.errorHandler;
 
   @override
-  Future<User> getUser() => client.getUser();
+  Future<BugsnagUser> getUser() => client.getUser();
 
   @override
   Future<void> setUser({String? id, String? email, String? name}) =>
@@ -358,14 +358,14 @@ class ChannelClient implements Client {
       _notifyUnhandled;
 
   @override
-  Future<User> getUser() async =>
-      User.fromJson(await _channel.invokeMethod('getUser'));
+  Future<BugsnagUser> getUser() async =>
+      BugsnagUser.fromJson(await _channel.invokeMethod('getUser'));
 
   @override
   Future<void> setUser({String? id, String? email, String? name}) =>
       _channel.invokeMethod(
         'setUser',
-        User(id: id, email: email, name: name),
+        BugsnagUser(id: id, email: email, name: name),
       );
 
   @override
@@ -648,7 +648,7 @@ class Bugsnag extends Client with DelegateClient {
   Future<void> start({
     String? apiKey,
     FutureOr<void> Function()? runApp,
-    User? user,
+    BugsnagUser? user,
     bool persistUser = true,
     String? context,
     String? appType,

--- a/packages/bugsnag_flutter/lib/src/model/event.dart
+++ b/packages/bugsnag_flutter/lib/src/model/event.dart
@@ -14,7 +14,7 @@ import 'user.dart';
 /// as a parameter on [OnErrorCallback], where individual properties can be
 /// mutated before an error report is sent to Bugsnag's API.
 class BugsnagEvent {
-  User _user;
+  BugsnagUser _user;
   bool _unhandled;
   final bool _originalUnhandled;
   final _SeverityReason _severityReason;
@@ -74,7 +74,7 @@ class BugsnagEvent {
   bool get unhandled => _unhandled;
 
   /// The User information associated with this event
-  User get user => _user;
+  BugsnagUser get user => _user;
 
   set unhandled(bool unhandled) {
     _unhandled = unhandled;
@@ -128,7 +128,7 @@ class BugsnagEvent {
 
   /// Sets the user associated with the event.
   void setUser({String? id, String? email, String? name}) {
-    _user = User(id: id, email: email, name: name);
+    _user = BugsnagUser(id: id, email: email, name: name);
   }
 
   BugsnagEvent.fromJson(Map<String, dynamic> json)
@@ -160,7 +160,7 @@ class BugsnagEvent {
         _session = json
             .safeGet<Map>('session')
             ?.let((session) => _Session.fromJson(session.cast())),
-        _user = User.fromJson(json['user']),
+        _user = BugsnagUser.fromJson(json['user']),
         device = DeviceWithState.fromJson(json['device']),
         app = AppWithState.fromJson(json['app']),
         _featureFlags = FeatureFlags.fromJson(

--- a/packages/bugsnag_flutter/lib/src/model/session.dart
+++ b/packages/bugsnag_flutter/lib/src/model/session.dart
@@ -4,12 +4,12 @@ import 'user.dart';
 class BugsnagSession {
   String id;
   DateTime startedAt;
-  User user;
+  BugsnagUser user;
 
   BugsnagSession.fromJson(Map<String, dynamic> json)
       : id = json['id'] as String,
         startedAt = DateTime.parse(json['startedAt']).toUtc(),
-        user = User.fromJson(json['user'] as Map<String, dynamic>);
+        user = BugsnagUser.fromJson(json['user'] as Map<String, dynamic>);
 
   dynamic toJson() => {
         'id': id,

--- a/packages/bugsnag_flutter/lib/src/model/user.dart
+++ b/packages/bugsnag_flutter/lib/src/model/user.dart
@@ -1,14 +1,14 @@
 import '_model_extensions.dart';
 
 /// Information about the current user of your application.
-class User {
+class BugsnagUser {
   String? id;
   String? email;
   String? name;
 
-  User({this.id, this.email, this.name});
+  BugsnagUser({this.id, this.email, this.name});
 
-  User.fromJson(Map<String, dynamic> json)
+  BugsnagUser.fromJson(Map<String, dynamic> json)
       : id = json.safeGet('id'),
         email = json.safeGet('email'),
         name = json.safeGet('name');
@@ -22,7 +22,7 @@ class User {
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-      other is User &&
+      other is BugsnagUser &&
           runtimeType == other.runtimeType &&
           id == other.id &&
           email == other.email &&

--- a/packages/bugsnag_flutter/test/bugsnag_stacktrace_test.dart
+++ b/packages/bugsnag_flutter/test/bugsnag_stacktrace_test.dart
@@ -1,5 +1,5 @@
-import 'package:bugsnag_flutter/bugsnag_flutter.dart';
 import 'package:bugsnag_flutter/src/bugsnag_stacktrace.dart';
+import 'package:bugsnag_flutter/src/model.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {

--- a/packages/bugsnag_flutter/test/channel_client_test.dart
+++ b/packages/bugsnag_flutter/test/channel_client_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:bugsnag_flutter/bugsnag_flutter.dart';
 import 'package:bugsnag_flutter/src/client.dart';
+import 'package:bugsnag_flutter/src/model.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'test_channel.dart';

--- a/packages/bugsnag_flutter/test/error_factory_test.dart
+++ b/packages/bugsnag_flutter/test/error_factory_test.dart
@@ -1,5 +1,5 @@
-import 'package:bugsnag_flutter/bugsnag_flutter.dart';
 import 'package:bugsnag_flutter/src/error_factory.dart';
+import 'package:bugsnag_flutter/src/model.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 

--- a/packages/bugsnag_flutter/test/model/app_test.dart
+++ b/packages/bugsnag_flutter/test/model/app_test.dart
@@ -1,4 +1,4 @@
-import 'package:bugsnag_flutter/bugsnag_flutter.dart';
+import 'package:bugsnag_flutter/src/model.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {

--- a/packages/bugsnag_flutter/test/model/breadcrumbs_test.dart
+++ b/packages/bugsnag_flutter/test/model/breadcrumbs_test.dart
@@ -1,4 +1,4 @@
-import 'package:bugsnag_flutter/bugsnag_flutter.dart';
+import 'package:bugsnag_flutter/src/model.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {

--- a/packages/bugsnag_flutter/test/model/device_test.dart
+++ b/packages/bugsnag_flutter/test/model/device_test.dart
@@ -1,4 +1,4 @@
-import 'package:bugsnag_flutter/bugsnag_flutter.dart';
+import 'package:bugsnag_flutter/src/model.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {

--- a/packages/bugsnag_flutter/test/model/error_test.dart
+++ b/packages/bugsnag_flutter/test/model/error_test.dart
@@ -1,4 +1,4 @@
-import 'package:bugsnag_flutter/bugsnag_flutter.dart';
+import 'package:bugsnag_flutter/src/model.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {

--- a/packages/bugsnag_flutter/test/model/event_test.dart
+++ b/packages/bugsnag_flutter/test/model/event_test.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:bugsnag_flutter/bugsnag_flutter.dart';
+import 'package:bugsnag_flutter/src/model.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '_expected_fixture_objects.dart';

--- a/packages/bugsnag_flutter/test/model/metadata_test.dart
+++ b/packages/bugsnag_flutter/test/model/metadata_test.dart
@@ -1,4 +1,4 @@
-import 'package:bugsnag_flutter/bugsnag_flutter.dart';
+import 'package:bugsnag_flutter/src/model.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 

--- a/packages/bugsnag_flutter/test/model/stackframe_test.dart
+++ b/packages/bugsnag_flutter/test/model/stackframe_test.dart
@@ -1,4 +1,4 @@
-import 'package:bugsnag_flutter/bugsnag_flutter.dart';
+import 'package:bugsnag_flutter/src/model.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 

--- a/packages/bugsnag_flutter/test/model/thread_test.dart
+++ b/packages/bugsnag_flutter/test/model/thread_test.dart
@@ -1,4 +1,4 @@
-import 'package:bugsnag_flutter/bugsnag_flutter.dart';
+import 'package:bugsnag_flutter/src/model.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '_json_equals.dart';

--- a/packages/bugsnag_flutter/test/model/user_test.dart
+++ b/packages/bugsnag_flutter/test/model/user_test.dart
@@ -7,13 +7,13 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   group('User', () {
     test('encodes / decodes from json', () {
-      final user = User(
+      final user = BugsnagUser(
         id: 'abc123',
         email: 'test-user@bugsnag.com',
         name: 'Bobby Tables',
       );
 
-      final unmarshalled = User.fromJson(user.toJson());
+      final unmarshalled = BugsnagUser.fromJson(user.toJson());
       expect(unmarshalled, equals(user));
     });
 
@@ -24,7 +24,7 @@ void main() {
         'name': 'Bobby Tables',
       };
 
-      final user = User(
+      final user = BugsnagUser(
         id: '321bca',
         email: 'another-test-user@bugsnag.com',
         name: 'Bobby Tables',
@@ -40,20 +40,20 @@ void main() {
         'name': 'Unexpected Michael',
       };
 
-      final expectedUser = User(
+      final expectedUser = BugsnagUser(
         id: '321bca',
         email: 'definitely-not-the@inquisition.com',
         name: 'Unexpected Michael',
       );
 
-      expect(User.fromJson(json), equals(expectedUser));
+      expect(BugsnagUser.fromJson(json), equals(expectedUser));
     });
 
     test('decodes from json fixture', () async {
       final userJsonFile = File('test/fixtures/user_serialization.json');
       final json = jsonDecode(await userJsonFile.readAsString());
 
-      final user = User.fromJson(json);
+      final user = BugsnagUser.fromJson(json);
 
       expect(user.id, equals('123'));
       expect(user.email, equals('bob@example.com'));

--- a/packages/bugsnag_flutter/test/model/user_test.dart
+++ b/packages/bugsnag_flutter/test/model/user_test.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:bugsnag_flutter/bugsnag_flutter.dart';
+import 'package:bugsnag_flutter/src/model.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {


### PR DESCRIPTION
## Goal

Prevent exporting class names that are likely to clash with application code - e.g. `App`, `Device`, `User`.

## Changeset

Exports fewer classes from `bugsnag_flutter.dart` and renames `User` to `BugsnagUser`.

## Testing

Updates `OnErrorScenario` to ensure that `app` and `device` can still be accessed & manipulated.