### PR TITLE
Fix invalid null aware operator compiler warning

### DIFF
--- a/packages/bugsnag_flutter/lib/src/client.dart
+++ b/packages/bugsnag_flutter/lib/src/client.dart
@@ -524,7 +524,10 @@ class ChannelClient implements Client {
     final errorInfo = details?.informationCollector?.call() ?? [];
     final errorContext = details?.context?.toDescription();
     final errorLibrary = details?.library;
-    final lifecycleState = SchedulerBinding.instance?.lifecycleState.toString();
+    // SchedulerBinding.instance is nullable in Flutter <3.0.0
+    // ignore: unnecessary_cast
+    final schedulerBinding = SchedulerBinding.instance as SchedulerBinding?;
+    final lifecycleState = schedulerBinding?.lifecycleState.toString();
     final metadata = {
       if (buildID != null) 'buildID': buildID,
       if (errorContext != null) 'errorContext': errorContext,


### PR DESCRIPTION
## Goal

Fix the following compiler and lint warning:

```
: Warning: Operand of null-aware operation '?.' has type 'SchedulerBinding' which excludes null.
- 'SchedulerBinding' is from 'package:flutter/src/scheduler/binding.dart'
    final lifecycleState = SchedulerBinding.instance?.lifecycleState.toString();
                                            ^
```

## Changeset

Casts `SchedulerBinding.instance` to `SchedulerBinding?` because `// ignore: invalid_null_aware_operator` doesn't silence the compiler warning 🤷

Supersedes #125

## Testing

Verified locally with

```
Flutter 3.0.0 • channel stable • https://github.com/flutter/flutter.git
Framework • revision ee4e09cce0 (3 weeks ago) • 2022-05-09 16:45:18 -0700
Engine • revision d1b9a6938a
Tools • Dart 2.17.0 • DevTools 2.12.2
```