### PR TITLE
Prefix all class names and restore exports

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -10,7 +10,7 @@ void main() async => bugsnag.start(
       // Find your API key in the settings menu of your Bugsnag dashboard
       apiKey: 'add_your_api_key_here',
       // Specify in-project packages if you have multiple or are splitting debug info in your build (--split-debug-info)
-      projectPackages: const ProjectPackages.only({'bugsnag_example'}),
+      projectPackages: const BugsnagProjectPackages.only({'bugsnag_example'}),
       // onError callbacks can be used to modify or reject certain events
       onError: [
         (event) {

--- a/features/fixtures/app/lib/channels.dart
+++ b/features/fixtures/app/lib/channels.dart
@@ -21,7 +21,7 @@ class MazeRunnerChannels {
     });
   }
 
-  static Future<void> startBugsnag(EndpointConfiguration endpoints) {
+  static Future<void> startBugsnag(BugsnagEndpointConfiguration endpoints) {
     return platform.invokeMethod("startBugsnag", {
       'notifyEndpoint': endpoints.notify,
       'sessionEndpoint': endpoints.sessions,

--- a/features/fixtures/app/lib/main.dart
+++ b/features/fixtures/app/lib/main.dart
@@ -191,7 +191,7 @@ class _HomePageState extends State<MazeRunnerHomePage> {
     return scenarios[scenarioIndex].init();
   }
 
-  EndpointConfiguration _endpoints() => EndpointConfiguration(
+  BugsnagEndpointConfiguration _endpoints() => BugsnagEndpointConfiguration(
         _notifyEndpointController.value.text,
         _sessionEndpointController.value.text,
       );

--- a/features/fixtures/app/lib/scenarios/attach_bugsnag_scenario.dart
+++ b/features/fixtures/app/lib/scenarios/attach_bugsnag_scenario.dart
@@ -11,8 +11,8 @@ class AttachBugsnagScenario extends Scenario {
           bugsnag.setContext('flutter-test-context'),
           bugsnag.setUser(id: 'test-user-id', name: 'Old Man Tables'),
           bugsnag.addFeatureFlags(const [
-            FeatureFlag('demo-mode'),
-            FeatureFlag('sample-group', '123'),
+            BugsnagFeatureFlag('demo-mode'),
+            BugsnagFeatureFlag('sample-group', '123'),
           ]),
         ]);
 

--- a/features/fixtures/app/lib/scenarios/breadcrumbs_scenario.dart
+++ b/features/fixtures/app/lib/scenarios/breadcrumbs_scenario.dart
@@ -5,7 +5,7 @@ class BreadcrumbsScenario extends Scenario {
   @override
   Future<void> run() async {
     await bugsnag.start(
-      enabledBreadcrumbTypes: {EnabledBreadcrumbType.state},
+      enabledBreadcrumbTypes: {BugsnagEnabledBreadcrumbType.state},
       endpoints: endpoints,
     );
 
@@ -16,9 +16,9 @@ class BreadcrumbsScenario extends Scenario {
 
     final breadcrumbs = await bugsnag.getBreadcrumbs();
     expect(breadcrumbs[0].message, 'Bugsnag loaded');
-    expect(breadcrumbs[0].type, BreadcrumbType.state);
+    expect(breadcrumbs[0].type, BugsnagBreadcrumbType.state);
     expect(breadcrumbs[1].message, 'Manual breadcrumb');
-    expect(breadcrumbs[1].type, BreadcrumbType.manual);
+    expect(breadcrumbs[1].type, BugsnagBreadcrumbType.manual);
 
     await bugsnag.notify(Exception('BreadcrumbsScenarioException'), null);
   }

--- a/features/fixtures/app/lib/scenarios/detect_enabled_errors.dart
+++ b/features/fixtures/app/lib/scenarios/detect_enabled_errors.dart
@@ -9,7 +9,7 @@ class DetectEnabledErrorsScenario extends Scenario {
   @override
   Future<void> run() async {
     await bugsnag.start(
-      enabledErrorTypes: EnabledErrorTypes(
+      enabledErrorTypes: BugsnagEnabledErrorTypes(
         unhandledDartExceptions:
             extraConfig?.contains('detectDartExceptions') == true,
         unhandledJvmExceptions:

--- a/features/fixtures/app/lib/scenarios/feature_flags_scenario.dart
+++ b/features/fixtures/app/lib/scenarios/feature_flags_scenario.dart
@@ -9,18 +9,18 @@ class FeatureFlagsScenario extends Scenario {
     await bugsnag.start(
       endpoints: endpoints,
       featureFlags: const [
-        FeatureFlag('1'),
-        FeatureFlag('2', 'foo'),
-        FeatureFlag('3'),
+        BugsnagFeatureFlag('1'),
+        BugsnagFeatureFlag('2', 'foo'),
+        BugsnagFeatureFlag('3'),
       ],
     );
 
     await bugsnag.clearFeatureFlags();
 
     await bugsnag.addFeatureFlags(const [
-      FeatureFlag('one'),
-      FeatureFlag('two', 'foo'),
-      FeatureFlag('three'),
+      BugsnagFeatureFlag('one'),
+      BugsnagFeatureFlag('two', 'foo'),
+      BugsnagFeatureFlag('three'),
     ]);
     await bugsnag.addFeatureFlag('four');
     await bugsnag.addFeatureFlag('five', 'six');

--- a/features/fixtures/app/lib/scenarios/last_run_info_scenario.dart
+++ b/features/fixtures/app/lib/scenarios/last_run_info_scenario.dart
@@ -17,7 +17,8 @@ class LastRunInfoScenario extends Scenario {
       Exception('After launch'),
       null,
       callback: (event) async {
-        final lastRunInfo = (await bugsnag.getLastRunInfo())!;
+        final lastRunInfo =
+            await bugsnag.getLastRunInfo() as BugsnagLastRunInfo;
         event.addMetadata('lastRunInfo', {
           'consecutiveLaunchCrashes': lastRunInfo.consecutiveLaunchCrashes,
           'crashed': lastRunInfo.crashed,

--- a/features/fixtures/app/lib/scenarios/on_error_scenario.dart
+++ b/features/fixtures/app/lib/scenarios/on_error_scenario.dart
@@ -11,6 +11,7 @@ class OnErrorScenario extends Scenario {
           (event) {
             event.app.id = 'app_id';
             event.device.id = 'device_id';
+            event.severity = BugsnagSeverity.info;
             event.errors.first.message = 'Not ignored';
             return true;
           },

--- a/features/fixtures/app/lib/scenarios/project_packages_scenario.dart
+++ b/features/fixtures/app/lib/scenarios/project_packages_scenario.dart
@@ -7,7 +7,8 @@ class ProjectPackagesScenario extends Scenario {
   Future<void> run() async {
     await bugsnag.start(
       endpoints: endpoints,
-      projectPackages: const ProjectPackages.withDefaults({'test_package'}),
+      projectPackages:
+          const BugsnagProjectPackages.withDefaults({'test_package'}),
     );
     await bugsnag.notify(Exception(), null);
   }

--- a/features/fixtures/app/lib/scenarios/scenario.dart
+++ b/features/fixtures/app/lib/scenarios/scenario.dart
@@ -6,7 +6,7 @@ import 'package:flutter/widgets.dart';
 import '../channels.dart';
 
 abstract class Scenario {
-  late EndpointConfiguration endpoints;
+  late BugsnagEndpointConfiguration endpoints;
 
   String? extraConfig;
 

--- a/features/fixtures/app/lib/scenarios/start_bugsnag_scenario.dart
+++ b/features/fixtures/app/lib/scenarios/start_bugsnag_scenario.dart
@@ -18,11 +18,11 @@ class StartBugsnagScenario extends Scenario {
       redactedKeys: {'secret'},
       releaseStage: 'testing',
       enabledReleaseStages: {'testing'},
-      enabledBreadcrumbTypes: {EnabledBreadcrumbType.error},
+      enabledBreadcrumbTypes: {BugsnagEnabledBreadcrumbType.error},
       endpoints: endpoints,
       featureFlags: const [
-        FeatureFlag('demo-mode'),
-        FeatureFlag('sample-group', '123'),
+        BugsnagFeatureFlag('demo-mode'),
+        BugsnagFeatureFlag('sample-group', '123'),
       ],
       metadata: const {
         'custom': {
@@ -31,7 +31,7 @@ class StartBugsnagScenario extends Scenario {
           'password': 'not redacted'
         }
       },
-      sendThreads: ThreadSendPolicy.never,
+      sendThreads: BugsnagThreadSendPolicy.never,
       runApp: () async {
         await bugsnag.notify(
           Exception('Exception with attached info'),

--- a/features/on_error.feature
+++ b/features/on_error.feature
@@ -6,4 +6,5 @@ Feature: OnError callbacks
     Then the exception "message" equals "Not ignored"
     And the event "app.id" equals "app_id"
     And the event "device.id" equals "device_id"
+    And the event "severity" equals "info"
     And on iOS, the event "threads.0.stacktrace.0.symbolAddress" is not null

--- a/packages/bugsnag_flutter/lib/bugsnag_flutter.dart
+++ b/packages/bugsnag_flutter/lib/bugsnag_flutter.dart
@@ -1,8 +1,8 @@
 export 'src/breadcrumbs/navigation.dart';
-export 'src/callbacks.dart' show OnErrorCallback;
-export 'src/client.dart' show bugsnag, Client, Bugsnag, ProjectPackages;
+export 'src/callbacks.dart' show BugsnagOnErrorCallback;
+export 'src/client.dart'
+    show bugsnag, BugsnagClient, Bugsnag, BugsnagProjectPackages;
 export 'src/config.dart';
 export 'src/helpers.dart';
-export 'src/model/breadcrumbs.dart';
-export 'src/model/feature_flags.dart';
-export 'src/model/user.dart';
+export 'src/last_run_info.dart';
+export 'src/model.dart';

--- a/packages/bugsnag_flutter/lib/src/breadcrumbs/navigation.dart
+++ b/packages/bugsnag_flutter/lib/src/breadcrumbs/navigation.dart
@@ -74,7 +74,7 @@ class BugsnagNavigatorObserver extends NavigatorObserver {
     if (leaveBreadcrumbs) {
       bugsnag.leaveBreadcrumb(
         _operationDescription(function),
-        type: BreadcrumbType.navigation,
+        type: BugsnagBreadcrumbType.navigation,
         metadata: metadata,
       );
     }

--- a/packages/bugsnag_flutter/lib/src/callbacks.dart
+++ b/packages/bugsnag_flutter/lib/src/callbacks.dart
@@ -11,7 +11,7 @@ import 'model.dart';
 /// "on error" callbacks added in Dart are only triggered for events originating
 /// in Dart and will always be triggered before "on error" callbacks added
 /// in the native layer (on Android and iOS).
-typedef OnErrorCallback = FutureOr<bool> Function(BugsnagEvent event);
+typedef BugsnagOnErrorCallback = FutureOr<bool> Function(BugsnagEvent event);
 
 typedef _Callback<E> = FutureOr<bool> Function(E);
 

--- a/packages/bugsnag_flutter/lib/src/client.dart
+++ b/packages/bugsnag_flutter/lib/src/client.dart
@@ -19,7 +19,7 @@ final _notifier = {
   'version': '2.0.1'
 };
 
-abstract class Client {
+abstract class BugsnagClient {
   /// An utility error handling function that will send reported errors to
   /// Bugsnag as unhandled. The [errorHandler] is suitable for use with
   /// common Dart error callbacks such as [runZonedGuarded] or [Future.onError].
@@ -70,7 +70,7 @@ abstract class Client {
   Future<void> leaveBreadcrumb(
     String message, {
     Map<String, Object>? metadata,
-    BreadcrumbType type = BreadcrumbType.manual,
+    BugsnagBreadcrumbType type = BugsnagBreadcrumbType.manual,
   });
 
   /// Returns the current buffer of breadcrumbs that will be sent with captured
@@ -96,7 +96,7 @@ abstract class Client {
   /// - [addFeatureFlag]
   /// - [clearFeatureFlag]
   /// - [clearFeatureFlags]
-  Future<void> addFeatureFlags(List<FeatureFlag> featureFlags);
+  Future<void> addFeatureFlags(List<BugsnagFeatureFlag> featureFlags);
 
   /// Remove a single feature flag regardless of its current status. This will
   /// stop the specified feature flag from being reported. If the named feature
@@ -189,7 +189,7 @@ abstract class Client {
   Future<bool> resumeSession();
 
   /// Informs Bugsnag that the application has finished launching. Once this
-  /// has resolved [AppWithState.isLaunching] will always be false in any new
+  /// has resolved [BugsnagAppWithState.isLaunching] will always be false in any new
   /// error reports, and synchronous delivery will not be attempted on the next
   /// launch for any fatal crashes.
   Future<void> markLaunchCompleted();
@@ -200,7 +200,7 @@ abstract class Client {
   /// For example, this allows checking whether the app crashed on its last
   /// launch, which could be used to perform conditional behaviour to recover
   /// from crashes, such as clearing the app data cache.
-  Future<LastRunInfo?> getLastRunInfo();
+  Future<BugsnagLastRunInfo?> getLastRunInfo();
 
   /// Notify Bugsnag of a handled exception.
   ///
@@ -209,7 +209,7 @@ abstract class Client {
   Future<void> notify(
     dynamic error,
     StackTrace? stackTrace, {
-    OnErrorCallback? callback,
+    BugsnagOnErrorCallback? callback,
   });
 
   /// Add a "on error" callback, to execute code at the point where an error
@@ -229,16 +229,16 @@ abstract class Client {
   /// "on error" callbacks added here are only triggered for events originating
   /// in Dart and will always be triggered before "on error" callbacks added
   /// in the native layer (on Android and iOS).
-  void addOnError(OnErrorCallback onError);
+  void addOnError(BugsnagOnErrorCallback onError);
 
   /// Removes a previously added "on error" callback.
-  void removeOnError(OnErrorCallback onError);
+  void removeOnError(BugsnagOnErrorCallback onError);
 }
 
-class DelegateClient implements Client {
-  Client? _client;
+class DelegateClient implements BugsnagClient {
+  BugsnagClient? _client;
 
-  Client get client {
+  BugsnagClient get client {
     final localClient = _client;
     if (localClient == null) {
       throw Exception(
@@ -248,7 +248,7 @@ class DelegateClient implements Client {
     return localClient;
   }
 
-  set client(Client client) {
+  set client(BugsnagClient client) {
     _client = client;
   }
 
@@ -273,7 +273,7 @@ class DelegateClient implements Client {
   Future<void> leaveBreadcrumb(
     String message, {
     Map<String, Object>? metadata,
-    BreadcrumbType type = BreadcrumbType.manual,
+    BugsnagBreadcrumbType type = BugsnagBreadcrumbType.manual,
   }) =>
       client.leaveBreadcrumb(message, metadata: metadata, type: type);
 
@@ -285,7 +285,7 @@ class DelegateClient implements Client {
       client.addFeatureFlag(name, variant);
 
   @override
-  Future<void> addFeatureFlags(List<FeatureFlag> featureFlags) =>
+  Future<void> addFeatureFlags(List<BugsnagFeatureFlag> featureFlags) =>
       client.addFeatureFlags(featureFlags);
 
   @override
@@ -319,24 +319,25 @@ class DelegateClient implements Client {
   Future<void> markLaunchCompleted() => client.markLaunchCompleted();
 
   @override
-  Future<LastRunInfo?> getLastRunInfo() => client.getLastRunInfo();
+  Future<BugsnagLastRunInfo?> getLastRunInfo() => client.getLastRunInfo();
 
   @override
   Future<void> notify(
     dynamic error,
     StackTrace? stackTrace, {
-    OnErrorCallback? callback,
+    BugsnagOnErrorCallback? callback,
   }) =>
       client.notify(error, stackTrace, callback: callback);
 
   @override
-  void addOnError(OnErrorCallback onError) => client.addOnError(onError);
+  void addOnError(BugsnagOnErrorCallback onError) => client.addOnError(onError);
 
   @override
-  void removeOnError(OnErrorCallback onError) => client.removeOnError(onError);
+  void removeOnError(BugsnagOnErrorCallback onError) =>
+      client.removeOnError(onError);
 }
 
-class ChannelClient implements Client {
+class ChannelClient implements BugsnagClient {
   FlutterExceptionHandler? _previousFlutterOnError;
 
   ChannelClient(bool autoDetectErrors) {
@@ -379,7 +380,7 @@ class ChannelClient implements Client {
   Future<void> leaveBreadcrumb(
     String message, {
     Map<String, Object>? metadata,
-    BreadcrumbType type = BreadcrumbType.manual,
+    BugsnagBreadcrumbType type = BugsnagBreadcrumbType.manual,
   }) async {
     final crumb = BugsnagBreadcrumb(message, type: type, metadata: metadata);
     await _channel.invokeMethod('leaveBreadcrumb', crumb);
@@ -391,11 +392,11 @@ class ChannelClient implements Client {
           .map((e) => BugsnagBreadcrumb.fromJson(e)));
 
   @override
-  Future<void> addFeatureFlag(String name, [String? variant]) =>
-      _channel.invokeMethod('addFeatureFlags', [FeatureFlag(name, variant)]);
+  Future<void> addFeatureFlag(String name, [String? variant]) => _channel
+      .invokeMethod('addFeatureFlags', [BugsnagFeatureFlag(name, variant)]);
 
   @override
-  Future<void> addFeatureFlags(List<FeatureFlag> featureFlags) =>
+  Future<void> addFeatureFlags(List<BugsnagFeatureFlag> featureFlags) =>
       _channel.invokeMethod('addFeatureFlags', featureFlags);
 
   @override
@@ -445,18 +446,18 @@ class ChannelClient implements Client {
       _channel.invokeMethod('markLaunchCompleted');
 
   @override
-  Future<LastRunInfo?> getLastRunInfo() async {
+  Future<BugsnagLastRunInfo?> getLastRunInfo() async {
     final json = await _channel.invokeMethod('getLastRunInfo');
-    return (json == null) ? null : LastRunInfo.fromJson(json);
+    return (json == null) ? null : BugsnagLastRunInfo.fromJson(json);
   }
 
   @override
-  void addOnError(OnErrorCallback onError) {
+  void addOnError(BugsnagOnErrorCallback onError) {
     _onErrorCallbacks.add(onError);
   }
 
   @override
-  void removeOnError(OnErrorCallback onError) {
+  void removeOnError(BugsnagOnErrorCallback onError) {
     _onErrorCallbacks.remove(onError);
   }
 
@@ -470,9 +471,10 @@ class ChannelClient implements Client {
     bool unhandled,
     FlutterErrorDetails? details,
     StackTrace? stackTrace,
-    OnErrorCallback? callback,
+    BugsnagOnErrorCallback? callback,
   ) async {
-    final errorPayload = ErrorFactory.instance.createError(error, stackTrace);
+    final errorPayload =
+        BugsnagErrorFactory.instance.createError(error, stackTrace);
     final event = await _createEvent(
       errorPayload,
       details: details,
@@ -501,7 +503,7 @@ class ChannelClient implements Client {
   Future<void> notify(
     dynamic error,
     StackTrace? stackTrace, {
-    OnErrorCallback? callback,
+    BugsnagOnErrorCallback? callback,
   }) {
     return _notifyInternal(error, false, null, stackTrace, callback);
   }
@@ -573,7 +575,7 @@ class ChannelClient implements Client {
 ///
 /// See also:
 /// - [start]
-class Bugsnag extends Client with DelegateClient {
+class Bugsnag extends BugsnagClient with DelegateClient {
   Bugsnag._internal();
 
   /// Attach Bugsnag to an already initialised native notifier, optionally
@@ -605,7 +607,7 @@ class Bugsnag extends Client with DelegateClient {
   Future<void> attach({
     FutureOr<void> Function()? runApp,
     bool autoDetectErrors = true,
-    List<OnErrorCallback> onError = const [],
+    List<BugsnagOnErrorCallback> onError = const [],
   }) async {
     // make sure we can use Channels before calling runApp
     _runWithErrorDetection(
@@ -658,25 +660,27 @@ class Bugsnag extends Client with DelegateClient {
     String? appVersion,
     String? bundleVersion,
     String? releaseStage,
-    EnabledErrorTypes enabledErrorTypes = EnabledErrorTypes.all,
-    EndpointConfiguration endpoints = EndpointConfiguration.bugsnag,
+    BugsnagEnabledErrorTypes enabledErrorTypes = BugsnagEnabledErrorTypes.all,
+    BugsnagEndpointConfiguration endpoints =
+        BugsnagEndpointConfiguration.bugsnag,
     int maxBreadcrumbs = 50,
     int maxPersistedSessions = 128,
     int maxPersistedEvents = 32,
     bool autoTrackSessions = true,
     bool autoDetectErrors = true,
-    ThreadSendPolicy sendThreads = ThreadSendPolicy.always,
+    BugsnagThreadSendPolicy sendThreads = BugsnagThreadSendPolicy.always,
     int launchDurationMillis = 5000,
     bool sendLaunchCrashesSynchronously = true,
     int appHangThresholdMillis = appHangThresholdFatalOnly,
     Set<String> redactedKeys = const {'password'},
     Set<String> discardClasses = const {},
     Set<String>? enabledReleaseStages,
-    Set<EnabledBreadcrumbType>? enabledBreadcrumbTypes,
-    ProjectPackages projectPackages = const ProjectPackages.withDefaults({}),
+    Set<BugsnagEnabledBreadcrumbType>? enabledBreadcrumbTypes,
+    BugsnagProjectPackages projectPackages =
+        const BugsnagProjectPackages.withDefaults({}),
     Map<String, Map<String, Object>>? metadata,
-    List<FeatureFlag>? featureFlags,
-    List<OnErrorCallback> onError = const [],
+    List<BugsnagFeatureFlag>? featureFlags,
+    List<BugsnagOnErrorCallback> onError = const [],
     Directory? persistenceDirectory,
     int? versionCode,
   }) async {
@@ -691,7 +695,7 @@ class Bugsnag extends Client with DelegateClient {
     );
 
     if (projectPackages._includeDefaults) {
-      projectPackages += ProjectPackages.only(_findProjectPackages());
+      projectPackages += BugsnagProjectPackages.only(_findProjectPackages());
     }
 
     await ChannelClient._channel.invokeMethod('start', <String, dynamic>{
@@ -719,7 +723,7 @@ class Bugsnag extends Client with DelegateClient {
       if (enabledReleaseStages != null)
         'enabledReleaseStages': enabledReleaseStages.toList(),
       'enabledBreadcrumbTypes':
-          (enabledBreadcrumbTypes ?? EnabledBreadcrumbType.values)
+          (enabledBreadcrumbTypes ?? BugsnagEnabledBreadcrumbType.values)
               .map((e) => e._toName())
               .toList(),
       'projectPackages': projectPackages,
@@ -758,7 +762,7 @@ class Bugsnag extends Client with DelegateClient {
   static const int appHangThresholdFatalOnly = 2147483647;
 
   /// Safely report an error that occurred within a guardedZone - if attached
-  /// to a [Client] then use its [Client.errorHandler], otherwise push the error
+  /// to a [BugsnagClient] then use its [BugsnagClient.errorHandler], otherwise push the error
   /// upwards using [Zone.handleUncaughtError]
   void _reportZonedError(dynamic error, StackTrace stackTrace) {
     if (_client != null) {
@@ -797,12 +801,12 @@ class Bugsnag extends Client with DelegateClient {
 ///
 /// See also:
 /// - [Bugsnag.start]
-/// - [ProjectPackages.defaults]
-class ProjectPackages {
+/// - [BugsnagProjectPackages.defaults]
+class BugsnagProjectPackages {
   final bool _includeDefaults;
   final Set<String> _packageNames;
 
-  const ProjectPackages._internal(
+  const BugsnagProjectPackages._internal(
     this._packageNames,
     this._includeDefaults,
   );
@@ -812,7 +816,7 @@ class ProjectPackages {
   /// your application uses on Android.
   ///
   /// This does not include any [defaults](ProjectPackages.withDefaults).
-  const ProjectPackages.only(Set<String> packageNames)
+  const BugsnagProjectPackages.only(Set<String> packageNames)
       : this._internal(packageNames, false);
 
   /// Combine the given set of `packageNames` with the default packages.
@@ -821,10 +825,10 @@ class ProjectPackages {
   ///
   /// See also:
   /// - [Android Configuration.projectPackages](https://docs.bugsnag.com/platforms/android/configuration-options/#projectpackages)
-  const ProjectPackages.withDefaults(Set<String> additionalPackageNames)
+  const BugsnagProjectPackages.withDefaults(Set<String> additionalPackageNames)
       : this._internal(additionalPackageNames, true);
 
-  operator +(ProjectPackages other) => ProjectPackages._internal(
+  operator +(BugsnagProjectPackages other) => BugsnagProjectPackages._internal(
       _packageNames.union(other._packageNames),
       _includeDefaults || other._includeDefaults);
 

--- a/packages/bugsnag_flutter/lib/src/config.dart
+++ b/packages/bugsnag_flutter/lib/src/config.dart
@@ -1,4 +1,4 @@
-class EnabledErrorTypes {
+class BugsnagEnabledErrorTypes {
   final bool unhandledJvmExceptions;
   final bool unhandledDartExceptions;
   final bool crashes;
@@ -7,7 +7,7 @@ class EnabledErrorTypes {
   final bool appHangs;
   final bool anrs;
 
-  const EnabledErrorTypes({
+  const BugsnagEnabledErrorTypes({
     this.unhandledJvmExceptions = true,
     this.unhandledDartExceptions = true,
     this.crashes = true,
@@ -26,27 +26,28 @@ class EnabledErrorTypes {
         'anrs': anrs
       };
 
-  static const EnabledErrorTypes all = EnabledErrorTypes();
+  static const BugsnagEnabledErrorTypes all = BugsnagEnabledErrorTypes();
 }
 
 /// Set the endpoints to send data to. By default we'll send error reports to
 /// `https://notify.bugsnag.com`, and sessions to `https://sessions.bugsnag.com`,
 /// but you can override this if you are using Bugsnag Enterprise to point
 /// to your own Bugsnag endpoints.
-class EndpointConfiguration {
+class BugsnagEndpointConfiguration {
   /// Configures the endpoint to which events should be sent
   final String notify;
 
   /// Configures the endpoint to which sessions should be sent
   final String sessions;
 
-  const EndpointConfiguration(this.notify, this.sessions);
+  const BugsnagEndpointConfiguration(this.notify, this.sessions);
 
   dynamic toJson() => {'notify': notify, 'sessions': sessions};
 
   /// Default Bugsnag `EndpointConfiguration`
-  static const EndpointConfiguration bugsnag = EndpointConfiguration(
-      'https://notify.bugsnag.com', 'https://sessions.bugsnag.com');
+  static const BugsnagEndpointConfiguration bugsnag =
+      BugsnagEndpointConfiguration(
+          'https://notify.bugsnag.com', 'https://sessions.bugsnag.com');
 }
 
 /// Controls whether we should capture and serialize the state of all threads
@@ -54,7 +55,7 @@ class EndpointConfiguration {
 ///
 /// This affects the thread capturing behaviour of the native layers of
 /// iOS and Android.
-enum ThreadSendPolicy {
+enum BugsnagThreadSendPolicy {
   /// Threads should be captured for all events.
   always,
 
@@ -67,7 +68,7 @@ enum ThreadSendPolicy {
 
 /// Types of [breadcrumbs](BugsnagBreadcrumb) that can be enabled or disabled by
 /// setting `enabledBreadcrumbTypes` [Bugsnag.start]
-enum EnabledBreadcrumbType {
+enum BugsnagEnabledBreadcrumbType {
   navigation,
   request,
   process,

--- a/packages/bugsnag_flutter/lib/src/error_factory.dart
+++ b/packages/bugsnag_flutter/lib/src/error_factory.dart
@@ -3,10 +3,10 @@ import 'package:bugsnag_flutter/src/bugsnag_stacktrace.dart';
 import 'model/event.dart';
 import 'model/stackframe.dart';
 
-class ErrorFactory {
-  static const instance = ErrorFactory._internal();
+class BugsnagErrorFactory {
+  static const instance = BugsnagErrorFactory._internal();
 
-  const ErrorFactory._internal();
+  const BugsnagErrorFactory._internal();
 
   BugsnagError createError(dynamic error, [StackTrace? stackTrace]) {
     // we favour the stackTrace on the `error` object, if one exists as this is

--- a/packages/bugsnag_flutter/lib/src/helpers.dart
+++ b/packages/bugsnag_flutter/lib/src/helpers.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 
 import 'package:bugsnag_flutter/bugsnag_flutter.dart';
 
-extension ZoneHelpers on Client {
+extension ZoneHelpers on BugsnagClient {
   /// Exactly equivalent to:
   /// ```dart
   /// return runZonedGuarded(body, bugsnag.errorHandler);

--- a/packages/bugsnag_flutter/lib/src/last_run_info.dart
+++ b/packages/bugsnag_flutter/lib/src/last_run_info.dart
@@ -1,5 +1,5 @@
 /// Provides information about the last launch of the application, if there was one.
-class LastRunInfo {
+class BugsnagLastRunInfo {
   ///  The number times the app has consecutively crashed during its launch period.
   final int consecutiveLaunchCrashes;
 
@@ -10,7 +10,7 @@ class LastRunInfo {
   /// True if the previous app run ended with a crash during its launch period.
   final bool crashedDuringLaunch;
 
-  LastRunInfo.fromJson(Map<String, dynamic> json)
+  BugsnagLastRunInfo.fromJson(Map<String, dynamic> json)
       : consecutiveLaunchCrashes = json['consecutiveLaunchCrashes'] as int,
         crashed = json['crashed'] as bool,
         crashedDuringLaunch = json['crashedDuringLaunch'] as bool;

--- a/packages/bugsnag_flutter/lib/src/model/app.dart
+++ b/packages/bugsnag_flutter/lib/src/model/app.dart
@@ -4,10 +4,10 @@ import '_model_extensions.dart';
 /// this class. These values can be accessed and amended if necessary.
 ///
 /// See also:
-/// - [AppWithState]
+/// - [BugsnagAppWithState]
 /// - [BugsnagEvent]
-/// - [Device]
-class App {
+/// - [BugsnagDevice]
+class BugsnagApp {
   /// The architecture of the running application binary
   String? binaryArch;
 
@@ -38,7 +38,7 @@ class App {
   /// `AndroidManifest.xml` or [Bugsnag.start]
   int? versionCode;
 
-  App.fromJson(Map<String, Object?> json)
+  BugsnagApp.fromJson(Map<String, Object?> json)
       : binaryArch = json.safeGet('binaryArch'),
         buildUUID = json.safeGet('buildUUID'),
         bundleVersion = json.safeGet('bundleVersion'),
@@ -69,10 +69,10 @@ class App {
 /// class. These values can be accessed and amended if necessary.
 ///
 /// See also:
-/// - [App]
+/// - [BugsnagApp]
 /// - [BugsnagEvent]
-/// - [Device]
-class AppWithState extends App {
+/// - [BugsnagDevice]
+class BugsnagAppWithState extends BugsnagApp {
   /// The number of milliseconds the application was running before the
   /// event occurred
   int? duration;
@@ -89,7 +89,7 @@ class AppWithState extends App {
   /// - [Client.markLaunchCompleted]
   bool? isLaunching;
 
-  AppWithState.fromJson(Map<String, Object?> json)
+  BugsnagAppWithState.fromJson(Map<String, Object?> json)
       : duration = json.safeGet<num>('duration')?.toInt(),
         durationInForeground =
             json.safeGet<num>('durationInForeground')?.toInt(),

--- a/packages/bugsnag_flutter/lib/src/model/breadcrumbs.dart
+++ b/packages/bugsnag_flutter/lib/src/model/breadcrumbs.dart
@@ -3,21 +3,21 @@ import 'metadata.dart';
 
 class BugsnagBreadcrumb {
   String message;
-  BreadcrumbType type;
+  BugsnagBreadcrumbType type;
   MetadataSection? metadata;
 
   final DateTime timestamp;
 
   BugsnagBreadcrumb(
     this.message, {
-    this.type = BreadcrumbType.manual,
+    this.type = BugsnagBreadcrumbType.manual,
     this.metadata,
   }) : timestamp = DateTime.now().toUtc();
 
   BugsnagBreadcrumb.fromJson(Map<String, dynamic> json)
       : message = json.safeGet('name'),
         timestamp = DateTime.parse(json['timestamp'] as String).toUtc(),
-        type = BreadcrumbType.values.byName(json['type'] as String),
+        type = BugsnagBreadcrumbType.values.byName(json['type'] as String),
         metadata = json
             .safeGet<Map>('metaData')
             ?.let((map) => BugsnagMetadata.sanitizedMap(map.cast()));
@@ -30,7 +30,7 @@ class BugsnagBreadcrumb {
       };
 }
 
-enum BreadcrumbType {
+enum BugsnagBreadcrumbType {
   navigation,
   request,
   process,

--- a/packages/bugsnag_flutter/lib/src/model/device.dart
+++ b/packages/bugsnag_flutter/lib/src/model/device.dart
@@ -5,10 +5,10 @@ import '_model_extensions.dart';
 /// amended if necessary.
 ///
 /// See also:
-/// - [DeviceWithState]
+/// - [BugsnagDeviceWithState]
 /// - [BugsnagEvent]
-/// - [App]
-class Device {
+/// - [BugsnagApp]
+class BugsnagDevice {
   /// Android only: The Application Binary Interface used
   List<String>? cpuAbi;
 
@@ -43,7 +43,7 @@ class Device {
   /// The total number of bytes of memory on the device
   int? totalMemory;
 
-  Device.fromJson(Map<String, Object?> json)
+  BugsnagDevice.fromJson(Map<String, Object?> json)
       : cpuAbi = json.safeGet('cpuAbi'),
         id = json.safeGet('id'),
         jailbroken = json.safeGet('jailbroken'),
@@ -78,10 +78,10 @@ class Device {
 /// amended if necessary.
 ///
 /// See also:
-/// - [Device]
+/// - [BugsnagDevice]
 /// - [BugsnagEvent]
-/// - [App]
-class DeviceWithState extends Device {
+/// - [BugsnagApp]
+class BugsnagDeviceWithState extends BugsnagDevice {
   /// The number of free bytes of storage available on the device
   int? freeDisk;
 
@@ -95,7 +95,7 @@ class DeviceWithState extends Device {
   /// The timestamp on the device when the event occurred
   DateTime? time;
 
-  DeviceWithState.fromJson(Map<String, Object?> json)
+  BugsnagDeviceWithState.fromJson(Map<String, Object?> json)
       : freeDisk = json.safeGet<num>('freeDisk')?.toInt(),
         freeMemory = json.safeGet<num>('freeMemory')?.toInt(),
         orientation = json.safeGet('orientation'),

--- a/packages/bugsnag_flutter/lib/src/model/event.dart
+++ b/packages/bugsnag_flutter/lib/src/model/event.dart
@@ -20,7 +20,7 @@ class BugsnagEvent {
   final _SeverityReason _severityReason;
   final List<String> _projectPackages;
   final _Session? _session;
-  final FeatureFlags _featureFlags;
+  final BugsnagFeatureFlags _featureFlags;
   final BugsnagMetadata _metadata;
 
   String? apiKey;
@@ -53,24 +53,24 @@ class BugsnagEvent {
   String? groupingHash;
 
   /// The severity of the event. By default, unhandled exceptions will be
-  /// [Severity.error] and handled exceptions sent with [Client.notify]
-  /// [Severity.warning].
-  Severity severity;
+  /// [BugsnagSeverity.error] and handled exceptions sent with [Client.notify]
+  /// [BugsnagSeverity.warning].
+  BugsnagSeverity severity;
 
   /// Information set by the notifier about your device can be found in this
   /// field. These values can be accessed and amended if necessary.
-  DeviceWithState device;
+  BugsnagDeviceWithState device;
 
   /// Information set by the notifier about your app can be found in this field.
   /// These values can be accessed and amended if necessary.
-  AppWithState app;
+  BugsnagAppWithState app;
 
   /// Whether the event was a crash (i.e. unhandled) or handled error in which
   /// the system continued running.
   ///
   /// Unhandled errors count towards your stability score. If you don't want
   /// certain errors to count towards your stability score, you can alter this
-  /// property through an [OnErrorCallback]
+  /// property through a [BugsnagOnErrorCallback]
   bool get unhandled => _unhandled;
 
   /// The User information associated with this event
@@ -152,7 +152,7 @@ class BugsnagEvent {
         groupingHash = json['groupingHash'] as String?,
         _unhandled = json['unhandled'] == true,
         _originalUnhandled = json['unhandled'] == true,
-        severity = Severity.values.byName(json['severity']),
+        severity = BugsnagSeverity.values.byName(json['severity']),
         _severityReason = _SeverityReason.fromJson(json['severityReason']),
         _projectPackages =
             (json['projectPackages'] as List?)?.toList(growable: true).cast() ??
@@ -161,9 +161,9 @@ class BugsnagEvent {
             .safeGet<Map>('session')
             ?.let((session) => _Session.fromJson(session.cast())),
         _user = BugsnagUser.fromJson(json['user']),
-        device = DeviceWithState.fromJson(json['device']),
-        app = AppWithState.fromJson(json['app']),
-        _featureFlags = FeatureFlags.fromJson(
+        device = BugsnagDeviceWithState.fromJson(json['device']),
+        app = BugsnagAppWithState.fromJson(json['app']),
+        _featureFlags = BugsnagFeatureFlags.fromJson(
             json['featureFlags'].cast<Map<String, dynamic>>()),
         _metadata = json
                 .safeGet<Map>('metaData')
@@ -234,7 +234,7 @@ class _Session {
 }
 
 /// The severity of a [BugsnagEvent], one of [error], [warning] or [info].
-enum Severity {
+enum BugsnagSeverity {
   error,
   warning,
   info,

--- a/packages/bugsnag_flutter/lib/src/model/feature_flags.dart
+++ b/packages/bugsnag_flutter/lib/src/model/feature_flags.dart
@@ -5,14 +5,14 @@ import '_model_extensions.dart';
 /// be used to identify runtime experiments and groups when reporting errors.
 ///
 /// See also:
-/// - [FeatureFlags]
-class FeatureFlag {
+/// - [BugsnagFeatureFlags]
+class BugsnagFeatureFlag {
   final String name;
   final String? variant;
 
-  const FeatureFlag(this.name, [this.variant]);
+  const BugsnagFeatureFlag(this.name, [this.variant]);
 
-  FeatureFlag.fromJson(Map<String, Object?> json)
+  BugsnagFeatureFlag.fromJson(Map<String, Object?> json)
       : name = json.safeGet('featureFlag'),
         variant = json.safeGet('variant');
 
@@ -22,12 +22,12 @@ class FeatureFlag {
       };
 }
 
-class FeatureFlags {
+class BugsnagFeatureFlags {
   final Map<String, String?> _content;
 
-  FeatureFlags() : _content = {};
+  BugsnagFeatureFlags() : _content = {};
 
-  FeatureFlags.fromJson(List<Map<String, Object?>> json)
+  BugsnagFeatureFlags.fromJson(List<Map<String, Object?>> json)
       : _content = {
           for (final flagJson in json)
             flagJson['featureFlag'] as String: flagJson['variant'] as String?,
@@ -60,7 +60,7 @@ class FeatureFlags {
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-      other is FeatureFlags &&
+      other is BugsnagFeatureFlags &&
           runtimeType == other.runtimeType &&
           _content.deepEquals(other._content);
 

--- a/packages/bugsnag_flutter/test/channel_client_test.dart
+++ b/packages/bugsnag_flutter/test/channel_client_test.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:bugsnag_flutter/bugsnag_flutter.dart';
 import 'package:bugsnag_flutter/src/client.dart';
-import 'package:bugsnag_flutter/src/model.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'test_channel.dart';

--- a/packages/bugsnag_flutter/test/error_factory_test.dart
+++ b/packages/bugsnag_flutter/test/error_factory_test.dart
@@ -6,8 +6,8 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   group('ErrorFactory', () {
     test('Exception with String message', () {
-      final error =
-          ErrorFactory.instance.createError(Exception('this is a message'));
+      final error = BugsnagErrorFactory.instance
+          .createError(Exception('this is a message'));
 
       expect(error.type, equals(BugsnagErrorType.dart));
       // a surprise _ appears!
@@ -17,7 +17,7 @@ void main() {
     });
 
     test('Exception with an object message', () {
-      final error = ErrorFactory.instance.createError(Exception(main));
+      final error = BugsnagErrorFactory.instance.createError(Exception(main));
 
       expect(error.type, equals(BugsnagErrorType.dart));
       // a surprise _ appears!
@@ -30,7 +30,7 @@ void main() {
     test('Complex Exception with message', () {
       const exception =
           FormatException('could not parse input', 'invalid input', 0);
-      final error = ErrorFactory.instance.createError(exception);
+      final error = BugsnagErrorFactory.instance.createError(exception);
 
       expect(error.type, equals(BugsnagErrorType.dart));
       expect(error.errorClass, equals('FormatException'));
@@ -45,7 +45,7 @@ void main() {
 
     test('Simple FlutterError', () {
       final flutterError = FlutterError('This is a FlutterError');
-      final error = ErrorFactory.instance.createError(flutterError);
+      final error = BugsnagErrorFactory.instance.createError(flutterError);
 
       expect(error.type, equals(BugsnagErrorType.dart));
       expect(error.errorClass, equals('FlutterError'));
@@ -66,7 +66,7 @@ void main() {
         ),
       ]);
 
-      final error = ErrorFactory.instance.createError(flutterError);
+      final error = BugsnagErrorFactory.instance.createError(flutterError);
 
       expect(error.type, equals(BugsnagErrorType.dart));
       expect(error.errorClass, equals('FlutterError'));
@@ -82,7 +82,8 @@ void main() {
     });
 
     test('BadlyBehavedError', () {
-      final error = ErrorFactory.instance.createError(BadlyBehavedError());
+      final error =
+          BugsnagErrorFactory.instance.createError(BadlyBehavedError());
 
       expect(error.type, equals(BugsnagErrorType.dart));
       expect(error.errorClass, equals('BadlyBehavedError'));
@@ -91,7 +92,7 @@ void main() {
     });
 
     test('Thrown number', () {
-      final error = ErrorFactory.instance.createError(123);
+      final error = BugsnagErrorFactory.instance.createError(123);
 
       expect(error.type, equals(BugsnagErrorType.dart));
       expect(error.errorClass, equals('int'));
@@ -108,7 +109,7 @@ void main() {
         thrownError = e;
       }
 
-      final error = ErrorFactory.instance.createError(thrownError);
+      final error = BugsnagErrorFactory.instance.createError(thrownError);
       expect(error.errorClass, equals('FlutterError'));
       expect(error.stacktrace.length, greaterThan(1));
 

--- a/packages/bugsnag_flutter/test/model/app_test.dart
+++ b/packages/bugsnag_flutter/test/model/app_test.dart
@@ -14,7 +14,7 @@ void main() {
         'versionCode': 34
       };
 
-      final app = App.fromJson(json);
+      final app = BugsnagApp.fromJson(json);
       expect(app.binaryArch, 'arm64');
       expect(app.buildUUID, 'test-7.5.3');
       expect(app.id, 'com.bugsnag.android.mazerunner');
@@ -37,7 +37,7 @@ void main() {
         'version': '12.3'
       };
 
-      final app = App.fromJson(json);
+      final app = BugsnagApp.fromJson(json);
       expect(app.binaryArch, 'x86_64');
       expect(app.bundleVersion, '12301');
       expect(app.dsymUuids, ['AC9210F7-55B6-3C88-8BA5-3004AA1A1D4E']);
@@ -66,7 +66,7 @@ void main() {
         'versionCode': 34,
       };
 
-      final app = AppWithState.fromJson(json);
+      final app = BugsnagAppWithState.fromJson(json);
       expect(app.binaryArch, 'arm64');
       expect(app.buildUUID, 'test-7.5.3');
       expect(app.duration, 45);
@@ -97,7 +97,7 @@ void main() {
         'version': '12.3'
       };
 
-      final app = AppWithState.fromJson(json);
+      final app = BugsnagAppWithState.fromJson(json);
       expect(app.binaryArch, 'x86_64');
       expect(app.bundleVersion, '12301');
       expect(app.dsymUuids, ['AC9210F7-55B6-3C88-8BA5-3004AA1A1D4E']);

--- a/packages/bugsnag_flutter/test/model/breadcrumbs_test.dart
+++ b/packages/bugsnag_flutter/test/model/breadcrumbs_test.dart
@@ -15,7 +15,8 @@ void main() {
     });
 
     test('breadcrumb with no metadata toJson', () {
-      final breadcrumb = BugsnagBreadcrumb('oak', type: BreadcrumbType.log);
+      final breadcrumb =
+          BugsnagBreadcrumb('oak', type: BugsnagBreadcrumbType.log);
       final json = breadcrumb.toJson();
 
       expect(json['name'], equals('oak'));
@@ -33,7 +34,7 @@ void main() {
 
       final breadcrumb = BugsnagBreadcrumb.fromJson(json);
       expect(breadcrumb.message, equals('from all the way over the network'));
-      expect(breadcrumb.type, equals(BreadcrumbType.request));
+      expect(breadcrumb.type, equals(BugsnagBreadcrumbType.request));
       expect(breadcrumb.metadata, isNull);
       expect(breadcrumb.timestamp,
           equals(DateTime.utc(2022, 3, 3, 2, 15, 50, 405)));
@@ -49,7 +50,7 @@ void main() {
 
       final breadcrumb = BugsnagBreadcrumb.fromJson(json);
       expect(breadcrumb.message, equals('from all the way over the network'));
-      expect(breadcrumb.type, equals(BreadcrumbType.request));
+      expect(breadcrumb.type, equals(BugsnagBreadcrumbType.request));
       expect(breadcrumb.metadata, equals({'some string': 'value goes here'}));
       expect(breadcrumb.timestamp,
           equals(DateTime.utc(2022, 3, 3, 2, 15, 50, 405)));

--- a/packages/bugsnag_flutter/test/model/device_test.dart
+++ b/packages/bugsnag_flutter/test/model/device_test.dart
@@ -20,7 +20,7 @@ void main() {
         'totalMemory': 7823929344
       };
 
-      final device = Device.fromJson(json);
+      final device = BugsnagDevice.fromJson(json);
       expect(device.cpuAbi, ['arm64-v8a', 'armeabi-v7a', 'armeabi']);
       expect(device.id, 'b97e2a6b-65d6-4e9d-a010-aa737eae3d33');
       expect(device.jailbroken, false);
@@ -54,7 +54,7 @@ void main() {
         'totalMemory': 68714848256
       };
 
-      final device = Device.fromJson(json);
+      final device = BugsnagDevice.fromJson(json);
       expect(device.cpuAbi, null);
       expect(device.id, '48decb8cf9f410c4c20e6f597070ee60b131a5c4');
       expect(device.jailbroken, false);
@@ -94,7 +94,7 @@ void main() {
         'totalMemory': 7823929344,
       };
 
-      final device = DeviceWithState.fromJson(json);
+      final device = BugsnagDeviceWithState.fromJson(json);
       expect(device.cpuAbi, ['arm64-v8a', 'armeabi-v7a', 'armeabi']);
       expect(device.freeDisk, 112632418304);
       expect(device.freeMemory, 3759054848);
@@ -139,7 +139,7 @@ void main() {
         'totalMemory': 68717121536,
       };
 
-      final device = DeviceWithState.fromJson(json);
+      final device = BugsnagDeviceWithState.fromJson(json);
       expect(device.cpuAbi, null);
       expect(device.freeDisk, 225370066944);
       expect(device.freeMemory, 34524872704);

--- a/packages/bugsnag_flutter/test/model/feature_flags_test.dart
+++ b/packages/bugsnag_flutter/test/model/feature_flags_test.dart
@@ -11,18 +11,18 @@ void main() {
         {'featureFlag': 'sample-group', 'variant': 'groupA'},
       ];
 
-      final expectedFlags = FeatureFlags();
+      final expectedFlags = BugsnagFeatureFlags();
       expectedFlags.addFeatureFlag('demo-mode');
       expectedFlags['sample-group'] = 'groupA';
 
-      final flags = FeatureFlags.fromJson(featureFlagJson);
+      final flags = BugsnagFeatureFlags.fromJson(featureFlagJson);
 
       expect(flags, equals(expectedFlags));
       expect(flags, jsonEquals(expectedFlags));
     });
 
     test('can clear existing feature flags', () {
-      final flags = FeatureFlags();
+      final flags = BugsnagFeatureFlags();
       flags.addFeatureFlag('my-feature-flag');
       flags.addFeatureFlag('flag-with-variant', 'some variant');
       flags.clearFeatureFlags();
@@ -31,7 +31,7 @@ void main() {
     });
 
     test('can clear single feature flags', () {
-      final flags = FeatureFlags();
+      final flags = BugsnagFeatureFlags();
       flags.addFeatureFlag('my-feature-flag');
       flags.addFeatureFlag('flag-with-variant', 'some variant');
 
@@ -46,7 +46,7 @@ void main() {
     });
 
     test('produces expected JSON payloads', () {
-      final flags = FeatureFlags();
+      final flags = BugsnagFeatureFlags();
       flags.addFeatureFlag('my-feature-flag');
       flags.addFeatureFlag('flag-with-variant', 'some variant');
 
@@ -60,12 +60,12 @@ void main() {
     });
 
     test('serializes & deserializes', () {
-      final flags = FeatureFlags();
+      final flags = BugsnagFeatureFlags();
       flags.addFeatureFlag('flag-1');
       flags.addFeatureFlag('flag-2', 'a variant for flag-2');
       flags.addFeatureFlag('flag-3', 'a variant for flag-3');
 
-      final deserializedFlags = FeatureFlags.fromJson(flags.toJson());
+      final deserializedFlags = BugsnagFeatureFlags.fromJson(flags.toJson());
       expect(deserializedFlags, equals(flags));
     });
   });

--- a/packages/bugsnag_flutter/test/project_packages_test.dart
+++ b/packages/bugsnag_flutter/test/project_packages_test.dart
@@ -4,7 +4,8 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   group('ProjectPackages', () {
     test('withDefaults', () {
-      const testPackages = ProjectPackages.withDefaults({'my_package_name'});
+      const testPackages =
+          BugsnagProjectPackages.withDefaults({'my_package_name'});
 
       expect(
         testPackages.toJson(),
@@ -16,7 +17,7 @@ void main() {
     });
 
     test('only', () {
-      const testPackages = ProjectPackages.only({'my_package_name'});
+      const testPackages = BugsnagProjectPackages.only({'my_package_name'});
 
       expect(
         testPackages.toJson(),


### PR DESCRIPTION
## Goal

Prefix all class names for consistency.

Revert to previously exported classes and types.

The only remaining unprefixed classes are internal / hidden ones:

```
$ grep -r ^class packages/bugsnag_flutter/lib | grep -v Bugsnag 
packages/bugsnag_flutter/lib/src/bugsnag_stacktrace.dart:class _Frame {
packages/bugsnag_flutter/lib/src/model/event.dart:class _SeverityReason {
packages/bugsnag_flutter/lib/src/model/event.dart:class _Session {
```