### PR TITLE
Add multiple versions of Flutter to the CI pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -63,7 +63,7 @@ steps:
   # iOS
   #
   - label: Build iOS Test Fixture 2.8.1
-    key: "ios-fixture-2-0-0"
+    key: "ios-fixture-2-8-1"
     timeout_in_minutes: 20
     env:
       FLUTTER_DIR: "/opt/flutter/2.8.1/bin/flutter"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -91,7 +91,7 @@ steps:
           to: "features/fixtures/app/build/ios/ipa/app-3.0.1.ipa"
 
   - label: 'iOS 14 end-to-end tests 2.8.1'
-    depends_on: "ios-fixture-2-0-0"
+    depends_on: "ios-fixture-2-8-1"
     timeout_in_minutes: 10
     env:
       FLUTTER_DIR: "/opt/flutter/2.8.1/bin/flutter"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,35 +6,35 @@ steps:
   - label: ":test_tube: 2.8.1"
     timeout_in_minutes: 10
     env:
-      FLUTTER_DIR: "/opt/flutter/2.8.1/bin/flutter"
+      FLUTTER_BIN: "/opt/flutter/2.8.1/bin/flutter"
     commands:
       - make test
 
   - label: ":test_tube: 3.0.1"
     timeout_in_minutes: 10
     env:
-      FLUTTER_DIR: "/opt/flutter/3.0.1/bin/flutter"
+      FLUTTER_BIN: "/opt/flutter/3.0.1/bin/flutter"
     commands:
       - make test
 
   - label: ":lint-roller: 2.8.1"
     timeout_in_minutes: 10
     env:
-      FLUTTER_DIR: "/opt/flutter/2.8.1/bin/flutter"
+      FLUTTER_BIN: "/opt/flutter/2.8.1/bin/flutter"
     commands:
       - make lint
 
   - label: ":lint-roller: 3.0.1"
     timeout_in_minutes: 10
     env:
-      FLUTTER_DIR: "/opt/flutter/3.0.1/bin/flutter"
+      FLUTTER_BIN: "/opt/flutter/3.0.1/bin/flutter"
     commands:
       - make lint
 
   - label: Build Example App 2.8.1
     timeout_in_minutes: 10
     env:
-      FLUTTER_DIR: "/opt/flutter/2.8.1/bin/flutter"
+      FLUTTER_BIN: "/opt/flutter/2.8.1/bin/flutter"
     commands:
       - pod repo update
       - make example
@@ -48,7 +48,7 @@ steps:
   - label: Build Example App 3.0.1
     timeout_in_minutes: 10
     env:
-      FLUTTER_DIR: "/opt/flutter/3.0.1/bin/flutter"
+      FLUTTER_BIN: "/opt/flutter/3.0.1/bin/flutter"
     commands:
       - pod repo update
       - make example
@@ -66,7 +66,7 @@ steps:
     key: "ios-fixture-2-8-1"
     timeout_in_minutes: 20
     env:
-      FLUTTER_DIR: "/opt/flutter/2.8.1/bin/flutter"
+      FLUTTER_BIN: "/opt/flutter/2.8.1/bin/flutter"
     commands:
       - pod repo update trunk
       - features/scripts/build_ios_app.sh
@@ -80,7 +80,7 @@ steps:
     key: "ios-fixture-3-0-1"
     timeout_in_minutes: 20
     env:
-      FLUTTER_DIR: "/opt/flutter/3.0.1/bin/flutter"
+      FLUTTER_BIN: "/opt/flutter/3.0.1/bin/flutter"
     commands:
       - pod repo update trunk
       - features/scripts/build_ios_app.sh
@@ -94,7 +94,7 @@ steps:
     depends_on: "ios-fixture-2-8-1"
     timeout_in_minutes: 10
     env:
-      FLUTTER_DIR: "/opt/flutter/2.8.1/bin/flutter"
+      FLUTTER_BIN: "/opt/flutter/2.8.1/bin/flutter"
     agents:
       queue: opensource
     plugins:
@@ -117,7 +117,7 @@ steps:
     depends_on: "ios-fixture-3-0-1"
     timeout_in_minutes: 10
     env:
-      FLUTTER_DIR: "/opt/flutter/3.0.1/bin/flutter"
+      FLUTTER_BIN: "/opt/flutter/3.0.1/bin/flutter"
     agents:
       queue: opensource
     plugins:
@@ -143,7 +143,7 @@ steps:
     key: "android-fixture-2-8-1"
     timeout_in_minutes: 20
     env:
-      FLUTTER_DIR: "/opt/flutter/2.8.1/bin/flutter"
+      FLUTTER_BIN: "/opt/flutter/2.8.1/bin/flutter"
     commands:
       - features/scripts/build_android_app.sh
     plugins:
@@ -156,7 +156,7 @@ steps:
     key: "android-fixture-3-0-1"
     timeout_in_minutes: 20
     env:
-      FLUTTER_DIR: "/opt/flutter/3.0.1/bin/flutter"
+      FLUTTER_BIN: "/opt/flutter/3.0.1/bin/flutter"
     commands:
       - features/scripts/build_android_app.sh
     plugins:
@@ -169,7 +169,7 @@ steps:
     depends_on: "android-fixture-2-8-1"
     timeout_in_minutes: 10
     env:
-      FLUTTER_DIR: "/opt/flutter/2.8.1/bin/flutter"
+      FLUTTER_BIN: "/opt/flutter/2.8.1/bin/flutter"
     agents:
       queue: opensource
     plugins:
@@ -192,7 +192,7 @@ steps:
     depends_on: "android-fixture-3-0-1"
     timeout_in_minutes: 10
     env:
-      FLUTTER_DIR: "/opt/flutter/3.0.1/bin/flutter"
+      FLUTTER_BIN: "/opt/flutter/3.0.1/bin/flutter"
     agents:
       queue: opensource
     plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,20 +1,54 @@
 agents:
-  queue: opensource-arm-mac-cocoa-12
+  queue: ms-arm-12-8
 
 steps:
 
-  - label: ":test_tube:"
+  - label: ":test_tube: 2.8.1"
     timeout_in_minutes: 10
+    env:
+      FLUTTER_VERSION: 2.8.1
     commands:
       - make test
 
-  - label: ":lint-roller:"
+  - label: ":test_tube: 3.0.1"
     timeout_in_minutes: 10
+    env:
+      FLUTTER_VERSION: 3.0.1
+    commands:
+      - make test
+
+  - label: ":lint-roller: 2.8.1"
+    timeout_in_minutes: 10
+    env:
+      FLUTTER_VERSION: 2.8.1
     commands:
       - make lint
 
-  - label: Build Example App
+  - label: ":lint-roller: 3.0.1"
     timeout_in_minutes: 10
+    env:
+      FLUTTER_VERSION: 3.0.1
+    commands:
+      - make lint
+
+  - label: Build Example App 2.8.1
+    timeout_in_minutes: 10
+    env:
+      FLUTTER_VERSION: 2.8.1
+    commands:
+      - pod repo update
+      - make example
+      # Verify that App.framework's UUID (and therefore our `codeIdentifier`) changes when Dart code is touched
+      - dwarfdump --arch=arm64 --uuid example/build/ios/iphoneos/Runner.app/Frameworks/App.framework/App | tee uuid_before
+      - sed -i '' -e 's/add_your_api_key_here/my_api_key/' example/lib/main.dart
+      - make example
+      - dwarfdump --arch=arm64 --uuid example/build/ios/iphoneos/Runner.app/Frameworks/App.framework/App | tee uuid_after
+      - test "$(cat uuid_before)" != "$(cat uuid_after)"
+
+  - label: Build Example App 3.0.1
+    timeout_in_minutes: 10
+    env:
+      FLUTTER_VERSION: 3.0.1
     commands:
       - pod repo update
       - make example
@@ -28,19 +62,35 @@ steps:
   #
   # iOS
   #
-  - label: Build iOS Test Fixture
-    key: ios-fixture
+  - label: Build iOS Test Fixture 2.8.1
+    key: "ios-fixture-2-0-0"
     timeout_in_minutes: 20
+    env:
+      FLUTTER_VERSION: 2.8.1
     commands:
       - pod repo update trunk
       - features/scripts/build_ios_app.sh
     plugins:
       artifacts#v1.5.0:
-        upload: "features/fixtures/app/build/ios/ipa/app.ipa"
+        upload: "features/fixtures/app/build/ios/ipa/app-2.8.1.ipa"
 
-  - label: 'iOS 14 end-to-end tests'
-    depends_on: "ios-fixture"
+  - label: Build iOS Test Fixture 3.0.1
+    key: "ios-fixture-3-0-1"
+    timeout_in_minutes: 20
+    env:
+      FLUTTER_VERSION: 3.0.1
+    commands:
+      - pod repo update trunk
+      - features/scripts/build_ios_app.sh
+    plugins:
+      artifacts#v1.5.0:
+        upload: "features/fixtures/app/build/ios/ipa/app-3.0.1.ipa"
+
+  - label: 'iOS 14 end-to-end tests 2.8.1'
+    depends_on: "ios-fixture-2-0-0"
     timeout_in_minutes: 10
+    env:
+      FLUTTER_VERSION: 2.8.1
     agents:
       queue: opensource
     plugins:
@@ -51,7 +101,30 @@ steps:
         pull: maze-runner
         run: maze-runner
         command:
-          - "--app=/app/features/fixtures/app/build/ios/ipa/app.ipa"
+          - "--app=/app/features/fixtures/app/build/ios/ipa/app-2.8.1.ipa"
+          - "--farm=bs"
+          - "--device=IOS_14"
+          - "--fail-fast"
+    concurrency: 24
+    concurrency_group: 'browserstack-app'
+    concurrency_method: eager
+
+  - label: 'iOS 14 end-to-end tests 3.0.1'
+    depends_on: "ios-fixture-3-0-1"
+    timeout_in_minutes: 10
+    env:
+      FLUTTER_VERSION: 3.0.1
+    agents:
+      queue: opensource
+    plugins:
+      artifacts#v1.5.0:
+        download: "features/fixtures/app/build/ios/ipa/app-3.0.1.ipa"
+        upload: "maze_output/failed/**/*"
+      docker-compose#v3.7.0:
+        pull: maze-runner
+        run: maze-runner
+        command:
+          - "--app=/app/features/fixtures/app/build/ios/ipa/app-3.0.1.ipa"
           - "--farm=bs"
           - "--device=IOS_14"
           - "--fail-fast"
@@ -62,29 +135,67 @@ steps:
   #
   # Android
   #
-  - label: Build Android Test Fixture
-    key: android-fixture
+  - label: Build Android Test Fixture 2.8.1
+    key: "android-fixture-2-0-0"
     timeout_in_minutes: 20
+    env:
+      FLUTTER_VERSION: 2.8.1
     commands:
       - features/scripts/build_android_app.sh
     plugins:
       artifacts#v1.5.0:
-        upload: "features/fixtures/app/build/app/outputs/flutter-apk/app-release.apk"
+        upload: "features/fixtures/app/build/app/outputs/flutter-apk/app-release-2.8.1.apk"
 
-  - label: 'Android 12 end-to-end tests'
-    depends_on: "android-fixture"
+  - label: Build Android Test Fixture 3.0.1
+    key: "android-fixture-3-0-1"
+    timeout_in_minutes: 20
+    env:
+      FLUTTER_VERSION: 3.0.1
+    commands:
+      - features/scripts/build_android_app.sh
+    plugins:
+      artifacts#v1.5.0:
+        upload: "features/fixtures/app/build/app/outputs/flutter-apk/app-release-3.0.1.apk"
+
+  - label: 'Android 12 end-to-end tests 2.8.1'
+    depends_on: "android-fixture-2-0-0"
     timeout_in_minutes: 10
+    env:
+      FLUTTER_VERSION: 2.8.1
     agents:
       queue: opensource
     plugins:
       artifacts#v1.5.0:
-        download: "features/fixtures/app/build/app/outputs/flutter-apk/app-release.apk"
+        download: "features/fixtures/app/build/app/outputs/flutter-apk/app-release-2.8.1.apk"
         upload: "maze_output/failed/**/*"
       docker-compose#v3.7.0:
         pull: maze-runner
         run: maze-runner
         command:
-          - "--app=/app/features/fixtures/app/build/app/outputs/flutter-apk/app-release.apk"
+          - "--app=/app/features/fixtures/app/build/app/outputs/flutter-apk/app-release-2.8.1.apk"
+          - "--farm=bs"
+          - "--device=ANDROID_12_0"
+          - "--fail-fast"
+    concurrency: 24
+    concurrency_group: 'browserstack-app'
+    concurrency_method: eager
+
+  - label: 'Android 12 end-to-end tests 3.0.1'
+    depends_on: "android-fixture-3-0-1"
+    timeout_in_minutes: 10
+    env:
+      FLUTTER_VERSION: 3.0.1
+    agents:
+      queue: opensource
+    plugins:
+      artifacts#v1.5.0:
+        download: "features/fixtures/app/build/app/outputs/flutter-apk/app-release-3.0.1.apk"
+        upload: "maze_output/failed/**/*"
+      docker-compose#v3.7.0:
+        pull: maze-runner
+        run: maze-runner
+        command:
+          - "--app=/app/features/fixtures/app/build/app/outputs/flutter-apk/app-release-3.0.1.apk"
           - "--farm=bs"
           - "--device=ANDROID_12_0"
           - "--fail-fast"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -140,7 +140,7 @@ steps:
   # Android
   #
   - label: Build Android Test Fixture 2.8.1
-    key: "android-fixture-2-0-0"
+    key: "android-fixture-2-8-1"
     timeout_in_minutes: 20
     env:
       FLUTTER_DIR: "/opt/flutter/2.8.1/bin/flutter"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,35 +6,35 @@ steps:
   - label: ":test_tube: 2.8.1"
     timeout_in_minutes: 10
     env:
-      FLUTTER_VERSION: 2.8.1
+      FLUTTER_DIR: "/usr/local/bin/flutter-2.8.1"
     commands:
       - make test
 
   - label: ":test_tube: 3.0.1"
     timeout_in_minutes: 10
     env:
-      FLUTTER_VERSION: 3.0.1
+      FLUTTER_DIR: "/usr/local/bin/flutter-3.0.1"
     commands:
       - make test
 
   - label: ":lint-roller: 2.8.1"
     timeout_in_minutes: 10
     env:
-      FLUTTER_VERSION: 2.8.1
+      FLUTTER_DIR: "/usr/local/bin/flutter-2.8.1"
     commands:
       - make lint
 
   - label: ":lint-roller: 3.0.1"
     timeout_in_minutes: 10
     env:
-      FLUTTER_VERSION: 3.0.1
+      FLUTTER_DIR: "/usr/local/bin/flutter-3.0.1"
     commands:
       - make lint
 
   - label: Build Example App 2.8.1
     timeout_in_minutes: 10
     env:
-      FLUTTER_VERSION: 2.8.1
+      FLUTTER_DIR: "/usr/local/bin/flutter-2.8.1"
     commands:
       - pod repo update
       - make example
@@ -48,7 +48,7 @@ steps:
   - label: Build Example App 3.0.1
     timeout_in_minutes: 10
     env:
-      FLUTTER_VERSION: 3.0.1
+      FLUTTER_DIR: "/usr/local/bin/flutter-3.0.1"
     commands:
       - pod repo update
       - make example
@@ -66,7 +66,7 @@ steps:
     key: "ios-fixture-2-0-0"
     timeout_in_minutes: 20
     env:
-      FLUTTER_VERSION: 2.8.1
+      FLUTTER_DIR: "/usr/local/bin/flutter-2.8.1"
     commands:
       - pod repo update trunk
       - features/scripts/build_ios_app.sh
@@ -78,7 +78,7 @@ steps:
     key: "ios-fixture-3-0-1"
     timeout_in_minutes: 20
     env:
-      FLUTTER_VERSION: 3.0.1
+      FLUTTER_DIR: "/usr/local/bin/flutter-3.0.1"
     commands:
       - pod repo update trunk
       - features/scripts/build_ios_app.sh
@@ -90,7 +90,7 @@ steps:
     depends_on: "ios-fixture-2-0-0"
     timeout_in_minutes: 10
     env:
-      FLUTTER_VERSION: 2.8.1
+      FLUTTER_DIR: "/usr/local/bin/flutter-2.8.1"
     agents:
       queue: opensource
     plugins:
@@ -113,7 +113,7 @@ steps:
     depends_on: "ios-fixture-3-0-1"
     timeout_in_minutes: 10
     env:
-      FLUTTER_VERSION: 3.0.1
+      FLUTTER_DIR: "/usr/local/bin/flutter-3.0.1"
     agents:
       queue: opensource
     plugins:
@@ -139,7 +139,7 @@ steps:
     key: "android-fixture-2-0-0"
     timeout_in_minutes: 20
     env:
-      FLUTTER_VERSION: 2.8.1
+      FLUTTER_DIR: "/usr/local/bin/flutter-2.8.1"
     commands:
       - features/scripts/build_android_app.sh
     plugins:
@@ -150,7 +150,7 @@ steps:
     key: "android-fixture-3-0-1"
     timeout_in_minutes: 20
     env:
-      FLUTTER_VERSION: 3.0.1
+      FLUTTER_DIR: "/usr/local/bin/flutter-3.0.1"
     commands:
       - features/scripts/build_android_app.sh
     plugins:
@@ -161,7 +161,7 @@ steps:
     depends_on: "android-fixture-2-0-0"
     timeout_in_minutes: 10
     env:
-      FLUTTER_VERSION: 2.8.1
+      FLUTTER_DIR: "/usr/local/bin/flutter-2.8.1"
     agents:
       queue: opensource
     plugins:
@@ -184,7 +184,7 @@ steps:
     depends_on: "android-fixture-3-0-1"
     timeout_in_minutes: 10
     env:
-      FLUTTER_VERSION: 3.0.1
+      FLUTTER_DIR: "/usr/local/bin/flutter-3.0.1"
     agents:
       queue: opensource
     plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,5 @@
 agents:
-  queue: ms-arm-12-8
+  queue: macos-12-arm
 
 steps:
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -166,7 +166,7 @@ steps:
           to: "features/fixtures/app/build/app/outputs/flutter-apk/app-release-3.0.1.apk"
 
   - label: 'Android 12 end-to-end tests 2.8.1'
-    depends_on: "android-fixture-2-0-0"
+    depends_on: "android-fixture-2-8-1"
     timeout_in_minutes: 10
     env:
       FLUTTER_DIR: "/opt/flutter/2.8.1/bin/flutter"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -95,7 +95,7 @@ steps:
       queue: opensource
     plugins:
       artifacts#v1.5.0:
-        download: "features/fixtures/app/build/ios/ipa/app.ipa"
+        download: "features/fixtures/app/build/ios/ipa/app-2.8.1.ipa"
         upload: "maze_output/failed/**/*"
       docker-compose#v3.7.0:
         pull: maze-runner

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,35 +6,35 @@ steps:
   - label: ":test_tube: 2.8.1"
     timeout_in_minutes: 10
     env:
-      FLUTTER_DIR: "/usr/local/bin/flutter-2.8.1"
+      FLUTTER_DIR: "/opt/flutter/2.8.1/bin/flutter"
     commands:
       - make test
 
   - label: ":test_tube: 3.0.1"
     timeout_in_minutes: 10
     env:
-      FLUTTER_DIR: "/usr/local/bin/flutter-3.0.1"
+      FLUTTER_DIR: "/opt/flutter/3.0.1/bin/flutter"
     commands:
       - make test
 
   - label: ":lint-roller: 2.8.1"
     timeout_in_minutes: 10
     env:
-      FLUTTER_DIR: "/usr/local/bin/flutter-2.8.1"
+      FLUTTER_DIR: "/opt/flutter/2.8.1/bin/flutter"
     commands:
       - make lint
 
   - label: ":lint-roller: 3.0.1"
     timeout_in_minutes: 10
     env:
-      FLUTTER_DIR: "/usr/local/bin/flutter-3.0.1"
+      FLUTTER_DIR: "/opt/flutter/3.0.1/bin/flutter"
     commands:
       - make lint
 
   - label: Build Example App 2.8.1
     timeout_in_minutes: 10
     env:
-      FLUTTER_DIR: "/usr/local/bin/flutter-2.8.1"
+      FLUTTER_DIR: "/opt/flutter/2.8.1/bin/flutter"
     commands:
       - pod repo update
       - make example
@@ -48,7 +48,7 @@ steps:
   - label: Build Example App 3.0.1
     timeout_in_minutes: 10
     env:
-      FLUTTER_DIR: "/usr/local/bin/flutter-3.0.1"
+      FLUTTER_DIR: "/opt/flutter/3.0.1/bin/flutter"
     commands:
       - pod repo update
       - make example
@@ -66,7 +66,7 @@ steps:
     key: "ios-fixture-2-0-0"
     timeout_in_minutes: 20
     env:
-      FLUTTER_DIR: "/usr/local/bin/flutter-2.8.1"
+      FLUTTER_DIR: "/opt/flutter/2.8.1/bin/flutter"
     commands:
       - pod repo update trunk
       - features/scripts/build_ios_app.sh
@@ -80,7 +80,7 @@ steps:
     key: "ios-fixture-3-0-1"
     timeout_in_minutes: 20
     env:
-      FLUTTER_DIR: "/usr/local/bin/flutter-3.0.1"
+      FLUTTER_DIR: "/opt/flutter/3.0.1/bin/flutter"
     commands:
       - pod repo update trunk
       - features/scripts/build_ios_app.sh
@@ -94,7 +94,7 @@ steps:
     depends_on: "ios-fixture-2-0-0"
     timeout_in_minutes: 10
     env:
-      FLUTTER_DIR: "/usr/local/bin/flutter-2.8.1"
+      FLUTTER_DIR: "/opt/flutter/2.8.1/bin/flutter"
     agents:
       queue: opensource
     plugins:
@@ -117,7 +117,7 @@ steps:
     depends_on: "ios-fixture-3-0-1"
     timeout_in_minutes: 10
     env:
-      FLUTTER_DIR: "/usr/local/bin/flutter-3.0.1"
+      FLUTTER_DIR: "/opt/flutter/3.0.1/bin/flutter"
     agents:
       queue: opensource
     plugins:
@@ -143,7 +143,7 @@ steps:
     key: "android-fixture-2-0-0"
     timeout_in_minutes: 20
     env:
-      FLUTTER_DIR: "/usr/local/bin/flutter-2.8.1"
+      FLUTTER_DIR: "/opt/flutter/2.8.1/bin/flutter"
     commands:
       - features/scripts/build_android_app.sh
     plugins:
@@ -156,7 +156,7 @@ steps:
     key: "android-fixture-3-0-1"
     timeout_in_minutes: 20
     env:
-      FLUTTER_DIR: "/usr/local/bin/flutter-3.0.1"
+      FLUTTER_DIR: "/opt/flutter/3.0.1/bin/flutter"
     commands:
       - features/scripts/build_android_app.sh
     plugins:
@@ -169,7 +169,7 @@ steps:
     depends_on: "android-fixture-2-0-0"
     timeout_in_minutes: 10
     env:
-      FLUTTER_DIR: "/usr/local/bin/flutter-2.8.1"
+      FLUTTER_DIR: "/opt/flutter/2.8.1/bin/flutter"
     agents:
       queue: opensource
     plugins:
@@ -192,7 +192,7 @@ steps:
     depends_on: "android-fixture-3-0-1"
     timeout_in_minutes: 10
     env:
-      FLUTTER_DIR: "/usr/local/bin/flutter-3.0.1"
+      FLUTTER_DIR: "/opt/flutter/3.0.1/bin/flutter"
     agents:
       queue: opensource
     plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -72,7 +72,9 @@ steps:
       - features/scripts/build_ios_app.sh
     plugins:
       artifacts#v1.5.0:
-        upload: "features/fixtures/app/build/ios/ipa/app-2.8.1.ipa"
+        upload:
+          from: "features/fixtures/app/build/ios/ipa/app.ipa"
+          to: "features/fixtures/app/build/ios/ipa/app-2.8.1.ipa"
 
   - label: Build iOS Test Fixture 3.0.1
     key: "ios-fixture-3-0-1"
@@ -84,7 +86,9 @@ steps:
       - features/scripts/build_ios_app.sh
     plugins:
       artifacts#v1.5.0:
-        upload: "features/fixtures/app/build/ios/ipa/app-3.0.1.ipa"
+        upload:
+          from: "features/fixtures/app/build/ios/ipa/app.ipa"
+          to: "features/fixtures/app/build/ios/ipa/app-3.0.1.ipa"
 
   - label: 'iOS 14 end-to-end tests 2.8.1'
     depends_on: "ios-fixture-2-0-0"
@@ -144,7 +148,9 @@ steps:
       - features/scripts/build_android_app.sh
     plugins:
       artifacts#v1.5.0:
-        upload: "features/fixtures/app/build/app/outputs/flutter-apk/app-release-2.8.1.apk"
+        upload:
+          from: "features/fixtures/app/build/app/outputs/flutter-apk/app-release.apk"
+          to: "features/fixtures/app/build/app/outputs/flutter-apk/app-release-2.8.1.apk"
 
   - label: Build Android Test Fixture 3.0.1
     key: "android-fixture-3-0-1"
@@ -155,7 +161,9 @@ steps:
       - features/scripts/build_android_app.sh
     plugins:
       artifacts#v1.5.0:
-        upload: "features/fixtures/app/build/app/outputs/flutter-apk/app-release-3.0.1.apk"
+        upload:
+          from: "features/fixtures/app/build/app/outputs/flutter-apk/app-release.apk"
+          to: "features/fixtures/app/build/app/outputs/flutter-apk/app-release-3.0.1.apk"
 
   - label: 'Android 12 end-to-end tests 2.8.1'
     depends_on: "android-fixture-2-0-0"

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
-FLUTTER_VERSION?=3.0.1
+FLUTTER_DIR?=flutter
 
 all: format build lint test
 
 .PHONY: clean build bump aar example test format lint e2e_android_local e2e_ios_local
 
 clean:
-	cd packages/bugsnag_flutter &&  flutter-$(FLUTTER_VERSION) clean --suppress-analytics
-	cd example &&  flutter-$(FLUTTER_VERSION) clean --suppress-analytics && \
+	cd packages/bugsnag_flutter &&  $(FLUTTER_DIR) clean --suppress-analytics
+	cd example &&  $(FLUTTER_DIR) clean --suppress-analytics && \
 			rm -rf .idea bugsnag_flutter_example.iml \
 			       ios/{Pods,.symlinks,Podfile.lock} \
 				   ios/{Runner.xcworkspace,Runner.xcodeproj,Runner.xcodeproj/project.xcworkspace}/xcuserdata \
@@ -34,13 +34,13 @@ stage: clean
 	sed -i '' -e '1,2d' staging/CHANGELOG.md
 
 aar:
-	cd packages/bugsnag_flutter && flutter-$(FLUTTER_VERSION) build aar --suppress-analytics
+	cd packages/bugsnag_flutter && $(FLUTTER_DIR) build aar --suppress-analytics
 
 example:
-	cd example &&  flutter-$(FLUTTER_VERSION) build apk --suppress-analytics &&  flutter-$(FLUTTER_VERSION) build ios --no-codesign --suppress-analytics
+	cd example &&  $(FLUTTER_DIR) build apk --suppress-analytics &&  $(FLUTTER_DIR) build ios --no-codesign --suppress-analytics
 
 test:
-	cd packages/bugsnag_flutter && flutter-$(FLUTTER_VERSION) test -r expanded --suppress-analytics
+	cd packages/bugsnag_flutter && $(FLUTTER_DIR) test -r expanded --suppress-analytics
 
 test-fixtures: ## Build the end-to-end test fixtures
 	@./features/scripts/build_ios_app.sh
@@ -50,18 +50,18 @@ format:
 	flutter format packages/bugsnag_flutter example features/fixtures/app
 
 lint:
-	cd packages/bugsnag_flutter && flutter-$(FLUTTER_VERSION) analyze --suppress-analytics
+	cd packages/bugsnag_flutter && $(FLUTTER_DIR) analyze --suppress-analytics
 
 e2e_android_local: features/fixtures/app/build/app/outputs/flutter-apk/app-release.apk
 	$(HOME)/Library/Android/sdk/platform-tools/adb uninstall com.bugsnag.flutter.test.app || true
 	bundle exec maze-runner --app=$< --farm=local --os=android --os-version=10 $(FEATURES)
 
 features/fixtures/app/build/app/outputs/flutter-apk/app-release.apk: $(shell find packages/bugsnag_flutter features/fixtures/app/android/app/src features/fixtures/app/lib -type f)
-	cd features/fixtures/app && flutter-$(FLUTTER_VERSION) build apk
+	cd features/fixtures/app && $(FLUTTER_DIR) build apk
 
 e2e_ios_local: features/fixtures/app/build/ios/ipa/app.ipa
 	ideviceinstaller --uninstall com.bugsnag.flutter.test.app
 	bundle exec maze-runner --app=$< --farm=local --os=ios --os-version=15 --apple-team-id=372ZUL2ZB7 --udid="$(shell idevice_id -l)" $(FEATURES)
 
 features/fixtures/app/build/ios/ipa/app.ipa: $(shell find packages/bugsnag_flutter features/fixtures/app/ios/Runner features/fixtures/app/lib -type f)
-	cd features/fixtures/app && flutter-$(FLUTTER_VERSION) build ipa --export-options-plist=ios/exportOptions.plist
+	cd features/fixtures/app && $(FLUTTER_DIR) build ipa --export-options-plist=ios/exportOptions.plist

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
-FLUTTER_DIR?=flutter
+FLUTTER_BIN?=flutter
 
 all: format build lint test
 
 .PHONY: clean build bump aar example test format lint e2e_android_local e2e_ios_local
 
 clean:
-	cd packages/bugsnag_flutter &&  $(FLUTTER_DIR) clean --suppress-analytics
-	cd example &&  $(FLUTTER_DIR) clean --suppress-analytics && \
+	cd packages/bugsnag_flutter &&  $(FLUTTER_BIN) clean --suppress-analytics
+	cd example &&  $(FLUTTER_BIN) clean --suppress-analytics && \
 			rm -rf .idea bugsnag_flutter_example.iml \
 			       ios/{Pods,.symlinks,Podfile.lock} \
 				   ios/{Runner.xcworkspace,Runner.xcodeproj,Runner.xcodeproj/project.xcworkspace}/xcuserdata \
@@ -34,13 +34,13 @@ stage: clean
 	sed -i '' -e '1,2d' staging/CHANGELOG.md
 
 aar:
-	cd packages/bugsnag_flutter && $(FLUTTER_DIR) build aar --suppress-analytics
+	cd packages/bugsnag_flutter && $(FLUTTER_BIN) build aar --suppress-analytics
 
 example:
-	cd example &&  $(FLUTTER_DIR) build apk --suppress-analytics &&  $(FLUTTER_DIR) build ios --no-codesign --suppress-analytics
+	cd example &&  $(FLUTTER_BIN) build apk --suppress-analytics &&  $(FLUTTER_BIN) build ios --no-codesign --suppress-analytics
 
 test:
-	cd packages/bugsnag_flutter && $(FLUTTER_DIR) test -r expanded --suppress-analytics
+	cd packages/bugsnag_flutter && $(FLUTTER_BIN) test -r expanded --suppress-analytics
 
 test-fixtures: ## Build the end-to-end test fixtures
 	@./features/scripts/build_ios_app.sh
@@ -50,18 +50,18 @@ format:
 	flutter format packages/bugsnag_flutter example features/fixtures/app
 
 lint:
-	cd packages/bugsnag_flutter && $(FLUTTER_DIR) analyze --suppress-analytics
+	cd packages/bugsnag_flutter && $(FLUTTER_BIN) analyze --suppress-analytics
 
 e2e_android_local: features/fixtures/app/build/app/outputs/flutter-apk/app-release.apk
 	$(HOME)/Library/Android/sdk/platform-tools/adb uninstall com.bugsnag.flutter.test.app || true
 	bundle exec maze-runner --app=$< --farm=local --os=android --os-version=10 $(FEATURES)
 
 features/fixtures/app/build/app/outputs/flutter-apk/app-release.apk: $(shell find packages/bugsnag_flutter features/fixtures/app/android/app/src features/fixtures/app/lib -type f)
-	cd features/fixtures/app && $(FLUTTER_DIR) build apk
+	cd features/fixtures/app && $(FLUTTER_BIN) build apk
 
 e2e_ios_local: features/fixtures/app/build/ios/ipa/app.ipa
 	ideviceinstaller --uninstall com.bugsnag.flutter.test.app
 	bundle exec maze-runner --app=$< --farm=local --os=ios --os-version=15 --apple-team-id=372ZUL2ZB7 --udid="$(shell idevice_id -l)" $(FEATURES)
 
 features/fixtures/app/build/ios/ipa/app.ipa: $(shell find packages/bugsnag_flutter features/fixtures/app/ios/Runner features/fixtures/app/lib -type f)
-	cd features/fixtures/app && $(FLUTTER_DIR) build ipa --export-options-plist=ios/exportOptions.plist
+	cd features/fixtures/app && $(FLUTTER_BIN) build ipa --export-options-plist=ios/exportOptions.plist

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
+FLUTTER_VERSION?=3.0.1
+
 all: format build lint test
 
 .PHONY: clean build bump aar example test format lint e2e_android_local e2e_ios_local
 
 clean:
-	cd packages/bugsnag_flutter && flutter clean --suppress-analytics
-	cd example && flutter clean --suppress-analytics && \
+	cd packages/bugsnag_flutter &&  flutter-$(FLUTTER_VERSION) clean --suppress-analytics
+	cd example &&  flutter-$(FLUTTER_VERSION) clean --suppress-analytics && \
 			rm -rf .idea bugsnag_flutter_example.iml \
 			       ios/{Pods,.symlinks,Podfile.lock} \
 				   ios/{Runner.xcworkspace,Runner.xcodeproj,Runner.xcodeproj/project.xcworkspace}/xcuserdata \
@@ -32,13 +34,13 @@ stage: clean
 	sed -i '' -e '1,2d' staging/CHANGELOG.md
 
 aar:
-	cd packages/bugsnag_flutter && flutter build aar --suppress-analytics
+	cd packages/bugsnag_flutter && flutter-$(FLUTTER_VERSION) build aar --suppress-analytics
 
 example:
-	cd example && flutter build apk --suppress-analytics && flutter build ios --no-codesign --suppress-analytics
+	cd example &&  flutter-$(FLUTTER_VERSION) build apk --suppress-analytics &&  flutter-$(FLUTTER_VERSION) build ios --no-codesign --suppress-analytics
 
 test:
-	cd packages/bugsnag_flutter && flutter test -r expanded --suppress-analytics
+	cd packages/bugsnag_flutter && flutter-$(FLUTTER_VERSION) test -r expanded --suppress-analytics
 
 test-fixtures: ## Build the end-to-end test fixtures
 	@./features/scripts/build_ios_app.sh
@@ -48,18 +50,18 @@ format:
 	flutter format packages/bugsnag_flutter example features/fixtures/app
 
 lint:
-	cd packages/bugsnag_flutter && flutter analyze --suppress-analytics
+	cd packages/bugsnag_flutter && flutter-$(FLUTTER_VERSION) analyze --suppress-analytics
 
 e2e_android_local: features/fixtures/app/build/app/outputs/flutter-apk/app-release.apk
 	$(HOME)/Library/Android/sdk/platform-tools/adb uninstall com.bugsnag.flutter.test.app || true
 	bundle exec maze-runner --app=$< --farm=local --os=android --os-version=10 $(FEATURES)
 
 features/fixtures/app/build/app/outputs/flutter-apk/app-release.apk: $(shell find packages/bugsnag_flutter features/fixtures/app/android/app/src features/fixtures/app/lib -type f)
-	cd features/fixtures/app && flutter build apk
+	cd features/fixtures/app && flutter-$(FLUTTER_VERSION) build apk
 
 e2e_ios_local: features/fixtures/app/build/ios/ipa/app.ipa
 	ideviceinstaller --uninstall com.bugsnag.flutter.test.app
 	bundle exec maze-runner --app=$< --farm=local --os=ios --os-version=15 --apple-team-id=372ZUL2ZB7 --udid="$(shell idevice_id -l)" $(FEATURES)
 
 features/fixtures/app/build/ios/ipa/app.ipa: $(shell find packages/bugsnag_flutter features/fixtures/app/ios/Runner features/fixtures/app/lib -type f)
-	cd features/fixtures/app && flutter build ipa --export-options-plist=ios/exportOptions.plist
+	cd features/fixtures/app && flutter-$(FLUTTER_VERSION) build ipa --export-options-plist=ios/exportOptions.plist

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ test-fixtures: ## Build the end-to-end test fixtures
 	@./features/scripts/build_android_app.sh
 
 format:
-	flutter format packages/bugsnag_flutter example features/fixtures/app
+	$(FLUTTER_BIN) format packages/bugsnag_flutter example features/fixtures/app
 
 lint:
 	cd packages/bugsnag_flutter && $(FLUTTER_BIN) analyze --suppress-analytics

--- a/features/scripts/build_android_app.sh
+++ b/features/scripts/build_android_app.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 set -o errexit
 
+if [ -z "$FLUTTER_DIR" ]; then
+  FLUTTER_DIR="flutter"
+fi
+
 cd features/fixtures/app
-flutter-$FLUTTER_VERSION build apk
+$FLUTTER_DIR build apk
 
 mv ../../../features/fixtures/app/build/app/outputs/flutter-apk/app-release.apk ../../../features/fixtures/app/build/app/outputs/flutter-apk/app-release-$FLUTTER_VERSION.apk

--- a/features/scripts/build_android_app.sh
+++ b/features/scripts/build_android_app.sh
@@ -2,4 +2,6 @@
 set -o errexit
 
 cd features/fixtures/app
-flutter build apk
+flutter-$FLUTTER_VERSION build apk
+
+mv ../../../features/fixtures/app/build/app/outputs/flutter-apk/app-release.apk ../../../features/fixtures/app/build/app/outputs/flutter-apk/app-release-$FLUTTER_VERSION.apk

--- a/features/scripts/build_android_app.sh
+++ b/features/scripts/build_android_app.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 set -o errexit
 
-if [ -z "$FLUTTER_DIR" ]; then
-  FLUTTER_DIR="flutter"
+if [ -z "$FLUTTER_BIN" ]; then
+  FLUTTER_BIN="flutter"
 fi
 
+echo "Flutter Bin: $FLUTTER_BIN"
+
 cd features/fixtures/app
-$FLUTTER_DIR build apk
+$FLUTTER_BIN build apk

--- a/features/scripts/build_android_app.sh
+++ b/features/scripts/build_android_app.sh
@@ -7,5 +7,3 @@ fi
 
 cd features/fixtures/app
 $FLUTTER_DIR build apk
-
-mv ../../../features/fixtures/app/build/app/outputs/flutter-apk/app-release.apk ../../../features/fixtures/app/build/app/outputs/flutter-apk/app-release-$FLUTTER_VERSION.apk

--- a/features/scripts/build_ios_app.sh
+++ b/features/scripts/build_ios_app.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 set -o errexit
 
-if [ -z "$FLUTTER_DIR" ]; then
-  FLUTTER_DIR="flutter"
+if [ -z "$FLUTTER_BIN" ]; then
+  FLUTTER_BIN="flutter"
 fi
 
+echo "Flutter Bin: $FLUTTER_BIN"
+
 cd features/fixtures/app
-$FLUTTER_DIR build ipa --export-options-plist=ios/exportOptions.plist
+$FLUTTER_BIN build ipa --export-options-plist=ios/exportOptions.plist

--- a/features/scripts/build_ios_app.sh
+++ b/features/scripts/build_ios_app.sh
@@ -2,4 +2,6 @@
 set -o errexit
 
 cd features/fixtures/app
-flutter build ipa --export-options-plist=ios/exportOptions.plist
+flutter-$FLUTTER_VERSION build ipa --export-options-plist=ios/exportOptions.plist
+
+mv ../../../features/fixtures/app/build/ios/ipa/app.ipa ../../../features/fixtures/app/build/ios/ipa/app-$FLUTTER_VERSION.ipa

--- a/features/scripts/build_ios_app.sh
+++ b/features/scripts/build_ios_app.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 set -o errexit
 
+if [ -z "$FLUTTER_DIR" ]; then
+  FLUTTER_DIR="flutter"
+fi
+
 cd features/fixtures/app
-flutter-$FLUTTER_VERSION build ipa --export-options-plist=ios/exportOptions.plist
+$FLUTTER_DIR build ipa --export-options-plist=ios/exportOptions.plist
 
 mv ../../../features/fixtures/app/build/ios/ipa/app.ipa ../../../features/fixtures/app/build/ios/ipa/app-$FLUTTER_VERSION.ipa

--- a/features/scripts/build_ios_app.sh
+++ b/features/scripts/build_ios_app.sh
@@ -7,5 +7,3 @@ fi
 
 cd features/fixtures/app
 $FLUTTER_DIR build ipa --export-options-plist=ios/exportOptions.plist
-
-mv ../../../features/fixtures/app/build/ios/ipa/app.ipa ../../../features/fixtures/app/build/ios/ipa/app-$FLUTTER_VERSION.ipa


### PR DESCRIPTION
## Goal

Add support for multiple version of Flutter within the CI pipeline.

## Changeset

`Makefile` and build scripts have been updated to allow for multiple versions of Flutter while allowing for normal operation on local machines.

## Testing

Full CI has been run