### PR TITLE
Port to Flutter 2.5.0

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,10 +3,10 @@ agents:
 
 steps:
 
-  - label: ":test_tube: 2.8.1"
+  - label: ":test_tube: 2.5.0"
     timeout_in_minutes: 10
     env:
-      FLUTTER_BIN: "/opt/flutter/2.8.1/bin/flutter"
+      FLUTTER_BIN: "/opt/flutter/2.5.0/bin/flutter"
     commands:
       - make test
 
@@ -17,10 +17,10 @@ steps:
     commands:
       - make test
 
-  - label: ":lint-roller: 2.8.1"
+  - label: ":lint-roller: 2.5.0"
     timeout_in_minutes: 10
     env:
-      FLUTTER_BIN: "/opt/flutter/2.8.1/bin/flutter"
+      FLUTTER_BIN: "/opt/flutter/2.5.0/bin/flutter"
     commands:
       - make lint
 
@@ -31,10 +31,10 @@ steps:
     commands:
       - make lint
 
-  - label: Build Example App 2.8.1
+  - label: Build Example App 2.5.0
     timeout_in_minutes: 10
     env:
-      FLUTTER_BIN: "/opt/flutter/2.8.1/bin/flutter"
+      FLUTTER_BIN: "/opt/flutter/2.5.0/bin/flutter"
     commands:
       - pod repo update
       - make example
@@ -62,11 +62,11 @@ steps:
   #
   # iOS
   #
-  - label: Build iOS Test Fixture 2.8.1
+  - label: Build iOS Test Fixture 2.5.0
     key: "ios-fixture-2-8-1"
     timeout_in_minutes: 20
     env:
-      FLUTTER_BIN: "/opt/flutter/2.8.1/bin/flutter"
+      FLUTTER_BIN: "/opt/flutter/2.5.0/bin/flutter"
     commands:
       - pod repo update trunk
       - features/scripts/build_ios_app.sh
@@ -74,7 +74,7 @@ steps:
       artifacts#v1.5.0:
         upload:
           from: "features/fixtures/app/build/ios/ipa/app.ipa"
-          to: "features/fixtures/app/build/ios/ipa/app-2.8.1.ipa"
+          to: "features/fixtures/app/build/ios/ipa/app-2.5.0.ipa"
 
   - label: Build iOS Test Fixture 3.0.1
     key: "ios-fixture-3-0-1"
@@ -90,22 +90,22 @@ steps:
           from: "features/fixtures/app/build/ios/ipa/app.ipa"
           to: "features/fixtures/app/build/ios/ipa/app-3.0.1.ipa"
 
-  - label: 'iOS 14 end-to-end tests 2.8.1'
+  - label: 'iOS 14 end-to-end tests 2.5.0'
     depends_on: "ios-fixture-2-8-1"
     timeout_in_minutes: 10
     env:
-      FLUTTER_BIN: "/opt/flutter/2.8.1/bin/flutter"
+      FLUTTER_BIN: "/opt/flutter/2.5.0/bin/flutter"
     agents:
       queue: opensource
     plugins:
       artifacts#v1.5.0:
-        download: "features/fixtures/app/build/ios/ipa/app-2.8.1.ipa"
+        download: "features/fixtures/app/build/ios/ipa/app-2.5.0.ipa"
         upload: "maze_output/failed/**/*"
       docker-compose#v3.7.0:
         pull: maze-runner
         run: maze-runner
         command:
-          - "--app=/app/features/fixtures/app/build/ios/ipa/app-2.8.1.ipa"
+          - "--app=/app/features/fixtures/app/build/ios/ipa/app-2.5.0.ipa"
           - "--farm=bs"
           - "--device=IOS_14"
           - "--fail-fast"
@@ -139,18 +139,18 @@ steps:
   #
   # Android
   #
-  - label: Build Android Test Fixture 2.8.1
+  - label: Build Android Test Fixture 2.5.0
     key: "android-fixture-2-8-1"
     timeout_in_minutes: 20
     env:
-      FLUTTER_BIN: "/opt/flutter/2.8.1/bin/flutter"
+      FLUTTER_BIN: "/opt/flutter/2.5.0/bin/flutter"
     commands:
       - features/scripts/build_android_app.sh
     plugins:
       artifacts#v1.5.0:
         upload:
           from: "features/fixtures/app/build/app/outputs/flutter-apk/app-release.apk"
-          to: "features/fixtures/app/build/app/outputs/flutter-apk/app-release-2.8.1.apk"
+          to: "features/fixtures/app/build/app/outputs/flutter-apk/app-release-2.5.0.apk"
 
   - label: Build Android Test Fixture 3.0.1
     key: "android-fixture-3-0-1"
@@ -165,22 +165,22 @@ steps:
           from: "features/fixtures/app/build/app/outputs/flutter-apk/app-release.apk"
           to: "features/fixtures/app/build/app/outputs/flutter-apk/app-release-3.0.1.apk"
 
-  - label: 'Android 12 end-to-end tests 2.8.1'
+  - label: 'Android 12 end-to-end tests 2.5.0'
     depends_on: "android-fixture-2-8-1"
     timeout_in_minutes: 10
     env:
-      FLUTTER_BIN: "/opt/flutter/2.8.1/bin/flutter"
+      FLUTTER_BIN: "/opt/flutter/2.5.0/bin/flutter"
     agents:
       queue: opensource
     plugins:
       artifacts#v1.5.0:
-        download: "features/fixtures/app/build/app/outputs/flutter-apk/app-release-2.8.1.apk"
+        download: "features/fixtures/app/build/app/outputs/flutter-apk/app-release-2.5.0.apk"
         upload: "maze_output/failed/**/*"
       docker-compose#v3.7.0:
         pull: maze-runner
         run: maze-runner
         command:
-          - "--app=/app/features/fixtures/app/build/app/outputs/flutter-apk/app-release-2.8.1.apk"
+          - "--app=/app/features/fixtures/app/build/app/outputs/flutter-apk/app-release-2.5.0.apk"
           - "--farm=bs"
           - "--device=ANDROID_12_0"
           - "--fail-fast"

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion flutter.compileSdkVersion
+    compileSdkVersion flutter.hasProperty('compileSdkVersion') ? flutter.compileSdkVersion : 30
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -34,8 +34,8 @@ android {
 
     defaultConfig {
         applicationId "com.bugsnag.examples.flutter"
-        minSdkVersion flutter.minSdkVersion
-        targetSdkVersion flutter.targetSdkVersion
+        minSdkVersion flutter.hasProperty('minSdkVersion') ? flutter.minSdkVersion : 16
+        targetSdkVersion flutter.hasProperty('targetSdkVersion') ? flutter.targetSdkVersion : 30
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -2,7 +2,6 @@
     package="com.bugsnag.examples.flutter">
 
     <application
-        android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"
         android:label="Bugsnag Flutter Example">
         <activity

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -7,7 +7,7 @@ description: Demonstrates how to use the bugsnag_flutter package.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
 environment:
-  sdk: ">=2.15.1 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/features/fixtures/app/android/app/build.gradle
+++ b/features/fixtures/app/android/app/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion flutter.compileSdkVersion
+    compileSdkVersion flutter.hasProperty('compileSdkVersion') ? flutter.compileSdkVersion : 30
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -35,7 +35,7 @@ android {
     defaultConfig {
         applicationId "com.bugsnag.flutter.test.app"
         minSdkVersion 16
-        targetSdkVersion flutter.targetSdkVersion
+        targetSdkVersion flutter.hasProperty('targetSdkVersion') ? flutter.targetSdkVersion : 30
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/features/fixtures/app/android/app/src/main/AndroidManifest.xml
+++ b/features/fixtures/app/android/app/src/main/AndroidManifest.xml
@@ -5,7 +5,6 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
     <application
-        android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"
         android:label="app"
         android:networkSecurityConfig="@xml/network_security_config">

--- a/features/fixtures/app/android/app/src/main/java/com/bugsnag/flutter/test/app/MazeRunnerMethodCallHandler.java
+++ b/features/fixtures/app/android/app/src/main/java/com/bugsnag/flutter/test/app/MazeRunnerMethodCallHandler.java
@@ -26,7 +26,7 @@ import io.flutter.plugin.common.MethodChannel;
 
 public class MazeRunnerMethodCallHandler implements MethodChannel.MethodCallHandler {
     public static final String TAG = "MazeRunner";
-    private final Handler scenarioRunner = new Handler(Looper.getMainLooper());
+    private final Handler mainHandler = new Handler(Looper.getMainLooper());
     private final Context context;
 
     MazeRunnerMethodCallHandler(@NonNull Context context) {
@@ -103,9 +103,13 @@ public class MazeRunnerMethodCallHandler implements MethodChannel.MethodCallHand
             for (String line; (line = reader.readLine()) != null; ) {
                 sb.append(line);
             }
-            result.success(sb.toString());
+            mainHandler.post(() -> {
+                result.success(sb.toString());
+            });
         } catch (Exception e) {
-            result.error(e.getClass().getSimpleName(), e.getMessage(), commandUrl);
+            mainHandler.post(() -> {
+                result.error(e.getClass().getSimpleName(), e.getMessage(), commandUrl);
+            });
         }
     }
 
@@ -122,7 +126,7 @@ public class MazeRunnerMethodCallHandler implements MethodChannel.MethodCallHand
 
         if (scenario != null) {
             // we push all scenarios to the main thread to stop Flutter catching the exceptions
-            scenarioRunner.post(() -> {
+            mainHandler.post(() -> {
                 scenario.run(call.argument("extraConfig"));
                 result.success(null);
             });

--- a/features/fixtures/app/lib/scenarios/scenarios.dart
+++ b/features/fixtures/app/lib/scenarios/scenarios.dart
@@ -28,25 +28,28 @@ class ScenarioInfo<T extends Scenario> {
 }
 
 // Flutter obfuscation *requires* that we specify the name as a raw String in order to match the runtime class
-const List<ScenarioInfo<Scenario>> scenarios = [
-  ScenarioInfo('AppHangScenario', AppHangScenario.new),
-  ScenarioInfo('AttachBugsnagScenario', AttachBugsnagScenario.new),
-  ScenarioInfo('BreadcrumbsScenario', BreadcrumbsScenario.new),
-  ScenarioInfo('DetectEnabledErrorsScenario', DetectEnabledErrorsScenario.new),
-  ScenarioInfo('DiscardClassesScenario', DiscardClassesScenario.new),
-  ScenarioInfo('ErrorHandlerScenario', ErrorHandlerScenario.new),
-  ScenarioInfo('FeatureFlagsScenario', FeatureFlagsScenario.new),
-  ScenarioInfo('FFICrashScenario', FFICrashScenario.new),
-  ScenarioInfo('HandledExceptionScenario', HandledExceptionScenario.new),
-  ScenarioInfo('LastRunInfoScenario', LastRunInfoScenario.new),
-  ScenarioInfo('ManualSessionsScenario', ManualSessionsScenario.new),
-  ScenarioInfo('MetadataScenario', MetadataScenario.new),
-  ScenarioInfo('NativeCrashScenario', NativeCrashScenario.new),
-  ScenarioInfo('NavigatorBreadcrumbScenario', NavigatorBreadcrumbScenario.new),
-  ScenarioInfo('OnErrorScenario', OnErrorScenario.new),
-  ScenarioInfo('ProjectPackagesScenario', ProjectPackagesScenario.new),
-  ScenarioInfo('ReleaseStageScenario', ReleaseStageScenario.new),
-  ScenarioInfo('StartBugsnagScenario', StartBugsnagScenario.new),
-  ScenarioInfo('ThrowExceptionScenario', ThrowExceptionScenario.new),
-  ScenarioInfo('UnhandledExceptionScenario', UnhandledExceptionScenario.new),
+final List<ScenarioInfo<Scenario>> scenarios = [
+  ScenarioInfo('AppHangScenario', () => AppHangScenario()),
+  ScenarioInfo('AttachBugsnagScenario', () => AttachBugsnagScenario()),
+  ScenarioInfo('BreadcrumbsScenario', () => BreadcrumbsScenario()),
+  ScenarioInfo(
+      'DetectEnabledErrorsScenario', () => DetectEnabledErrorsScenario()),
+  ScenarioInfo('DiscardClassesScenario', () => DiscardClassesScenario()),
+  ScenarioInfo('ErrorHandlerScenario', () => ErrorHandlerScenario()),
+  ScenarioInfo('FeatureFlagsScenario', () => FeatureFlagsScenario()),
+  ScenarioInfo('FFICrashScenario', () => FFICrashScenario()),
+  ScenarioInfo('HandledExceptionScenario', () => HandledExceptionScenario()),
+  ScenarioInfo('LastRunInfoScenario', () => LastRunInfoScenario()),
+  ScenarioInfo('ManualSessionsScenario', () => ManualSessionsScenario()),
+  ScenarioInfo('MetadataScenario', () => MetadataScenario()),
+  ScenarioInfo('NativeCrashScenario', () => NativeCrashScenario()),
+  ScenarioInfo(
+      'NavigatorBreadcrumbScenario', () => NavigatorBreadcrumbScenario()),
+  ScenarioInfo('OnErrorScenario', () => OnErrorScenario()),
+  ScenarioInfo('ProjectPackagesScenario', () => ProjectPackagesScenario()),
+  ScenarioInfo('ReleaseStageScenario', () => ReleaseStageScenario()),
+  ScenarioInfo('StartBugsnagScenario', () => StartBugsnagScenario()),
+  ScenarioInfo('ThrowExceptionScenario', () => ThrowExceptionScenario()),
+  ScenarioInfo(
+      'UnhandledExceptionScenario', () => UnhandledExceptionScenario()),
 ];

--- a/features/fixtures/app/pubspec.lock
+++ b/features/fixtures/app/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.2"
+    version: "2.8.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,14 +21,14 @@ packages:
       path: "../../../packages/bugsnag_flutter"
       relative: true
     source: path
-    version: "2.0.0-rc5"
+    version: "2.0.2"
   characters:
     dependency: transitive
     description:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.1.0"
   charcode:
     dependency: transitive
     description:
@@ -108,14 +108,7 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.11"
-  material_color_utilities:
-    dependency: transitive
-    description:
-      name: material_color_utilities
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.1.3"
+    version: "0.12.10"
   meta:
     dependency: transitive
     description:
@@ -176,7 +169,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.8"
+    version: "0.4.2"
   typed_data:
     dependency: transitive
     description:
@@ -190,7 +183,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.0"
 sdks:
-  dart: ">=2.15.1 <3.0.0"
-  flutter: ">=2.0.0"
+  dart: ">=2.14.0 <3.0.0"
+  flutter: ">=2.5.0"

--- a/features/fixtures/app/pubspec.yaml
+++ b/features/fixtures/app/pubspec.yaml
@@ -18,8 +18,8 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.15.1 <3.0.0"
-  flutter: "2.0.0"
+  sdk: ">=2.12.0 <3.0.0"
+  flutter: "2.5.0"
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/packages/bugsnag_flutter/lib/src/bugsnag_stacktrace.dart
+++ b/packages/bugsnag_flutter/lib/src/bugsnag_stacktrace.dart
@@ -68,7 +68,7 @@ int? _parseBaseAddress(String line) {
 BugsnagStacktrace? _parseStackTrace(String stackTraceString) {
   try {
     return StackFrame.fromStackTrace(StackTrace.fromString(stackTraceString))
-        .map(BugsnagStackframe.fromStackFrame)
+        .map((frame) => BugsnagStackframe.fromStackFrame(frame))
         .toList();
   } catch (e) {
     return null;

--- a/packages/bugsnag_flutter/lib/src/client.dart
+++ b/packages/bugsnag_flutter/lib/src/client.dart
@@ -10,6 +10,7 @@ import 'package:flutter/widgets.dart' show WidgetsFlutterBinding;
 
 import 'callbacks.dart';
 import 'config.dart';
+import 'enum_utils.dart';
 import 'last_run_info.dart';
 import 'model.dart';
 
@@ -714,7 +715,7 @@ class Bugsnag extends BugsnagClient with DelegateClient {
       'maxPersistedEvents': maxPersistedEvents,
       'autoTrackSessions': autoTrackSessions,
       'autoDetectErrors': autoDetectErrors,
-      'sendThreads': sendThreads._toName(),
+      'sendThreads': sendThreads.toName(),
       'launchDurationMillis': launchDurationMillis,
       'sendLaunchCrashesSynchronously': sendLaunchCrashesSynchronously,
       'appHangThresholdMillis': appHangThresholdMillis,
@@ -724,7 +725,7 @@ class Bugsnag extends BugsnagClient with DelegateClient {
         'enabledReleaseStages': enabledReleaseStages.toList(),
       'enabledBreadcrumbTypes':
           (enabledBreadcrumbTypes ?? BugsnagEnabledBreadcrumbType.values)
-              .map((e) => e._toName())
+              .map((e) => e.toName())
               .toList(),
       'projectPackages': projectPackages,
       if (metadata != null) 'metadata': BugsnagMetadata(metadata),
@@ -840,8 +841,3 @@ class BugsnagProjectPackages {
 
 /// Primary access to the Bugsnag API, most calls to Bugsnag will start here
 final Bugsnag bugsnag = Bugsnag._internal();
-
-// The official EnumName extension was only added in 2.15
-extension _EnumName on Enum {
-  String _toName() => toString().split('.').last;
-}

--- a/packages/bugsnag_flutter/lib/src/enum_utils.dart
+++ b/packages/bugsnag_flutter/lib/src/enum_utils.dart
@@ -1,0 +1,15 @@
+// The official EnumName extension was only added in 2.15
+extension EnumName on Enum {
+  String toName() => toString().split('.').last;
+}
+
+// The official EnumByName extension was only added in 2.15
+extension EnumByName<T extends Enum> on Iterable<T> {
+  T findByName(String name) {
+    for (var value in this) {
+      if (value.toName() == name) return value;
+    }
+
+    throw ArgumentError.value(name, "name", "No enum value with that name");
+  }
+}

--- a/packages/bugsnag_flutter/lib/src/model/breadcrumbs.dart
+++ b/packages/bugsnag_flutter/lib/src/model/breadcrumbs.dart
@@ -1,3 +1,4 @@
+import '../enum_utils.dart';
 import '_model_extensions.dart';
 import 'metadata.dart';
 
@@ -17,14 +18,14 @@ class BugsnagBreadcrumb {
   BugsnagBreadcrumb.fromJson(Map<String, dynamic> json)
       : message = json.safeGet('name'),
         timestamp = DateTime.parse(json['timestamp'] as String).toUtc(),
-        type = BugsnagBreadcrumbType.values.byName(json['type'] as String),
+        type = BugsnagBreadcrumbType.values.findByName(json['type'] as String),
         metadata = json
             .safeGet<Map>('metaData')
             ?.let((map) => BugsnagMetadata.sanitizedMap(map.cast()));
 
   dynamic toJson() => {
         'name': message,
-        'type': type.name,
+        'type': type.toName(),
         'timestamp': timestamp.toIso8601String(),
         'metaData': metadata ?? {},
       };

--- a/packages/bugsnag_flutter/lib/src/model/event.dart
+++ b/packages/bugsnag_flutter/lib/src/model/event.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import '../enum_utils.dart';
 import '_model_extensions.dart';
 import 'app.dart';
 import 'breadcrumbs.dart';
@@ -152,7 +153,7 @@ class BugsnagEvent {
         groupingHash = json['groupingHash'] as String?,
         _unhandled = json['unhandled'] == true,
         _originalUnhandled = json['unhandled'] == true,
-        severity = BugsnagSeverity.values.byName(json['severity']),
+        severity = BugsnagSeverity.values.findByName(json['severity']),
         _severityReason = _SeverityReason.fromJson(json['severityReason']),
         _projectPackages =
             (json['projectPackages'] as List?)?.toList(growable: true).cast() ??
@@ -179,7 +180,7 @@ class BugsnagEvent {
       if (context != null) 'context': context,
       if (groupingHash != null) 'groupingHash': groupingHash,
       'unhandled': unhandled,
-      'severity': severity.name,
+      'severity': severity.toName(),
       'severityReason': _severityReason,
       'projectPackages': _projectPackages,
       'user': user,
@@ -260,7 +261,9 @@ class BugsnagError {
   BugsnagError.fromJson(Map<String, dynamic> json)
       : errorClass = json.safeGet('errorClass'),
         message = json.safeGet('message'),
-        type = json.safeGet<String>('type')?.let(BugsnagErrorType.forName) ??
+        type = json
+                .safeGet<String>('type')
+                ?.let((type) => BugsnagErrorType.forName(type)) ??
             (Platform.isAndroid
                 ? BugsnagErrorType.android
                 : BugsnagErrorType.cocoa),

--- a/packages/bugsnag_flutter/lib/src/model/stackframe.dart
+++ b/packages/bugsnag_flutter/lib/src/model/stackframe.dart
@@ -75,7 +75,9 @@ class BugsnagStackframe {
   });
 
   BugsnagStackframe.fromJson(Map<String, Object?> json)
-      : type = json.safeGet<String>('type')?.let(BugsnagErrorType.forName),
+      : type = json
+            .safeGet<String>('type')
+            ?.let((name) => BugsnagErrorType.forName(name)),
         file = json.safeGet('file'),
         lineNumber = json.safeGet<num>('lineNumber')?.toInt(),
         columnNumber = json.safeGet<num>('columnNumber')?.toInt(),
@@ -142,7 +144,7 @@ class BugsnagStackframe {
 
   static BugsnagStacktrace stacktraceFromJson(
           List<Map<String, dynamic>> json) =>
-      json.map(BugsnagStackframe.fromJson).toList();
+      json.map((element) => BugsnagStackframe.fromJson(element)).toList();
 }
 
 typedef BugsnagStacktrace = List<BugsnagStackframe>;

--- a/packages/bugsnag_flutter/lib/src/model/thread.dart
+++ b/packages/bugsnag_flutter/lib/src/model/thread.dart
@@ -43,7 +43,9 @@ class BugsnagThread {
         name = json.safeGet('name'),
         state = json.safeGet('state'),
         isErrorReportingThread = json.safeGet('errorReportingThread') == true,
-        type = json.safeGet<String>('type')?.let(BugsnagErrorType.forName) ??
+        type = json
+                .safeGet<String>('type')
+                ?.let((name) => BugsnagErrorType.forName(name)) ??
             (Platform.isAndroid
                 ? BugsnagErrorType.android
                 : BugsnagErrorType.cocoa),

--- a/packages/bugsnag_flutter/pubspec.yaml
+++ b/packages/bugsnag_flutter/pubspec.yaml
@@ -7,8 +7,8 @@ repository: https://github.com/bugsnag/bugsnag-flutter
 issue_tracker: https://github.com/bugsnag/bugsnag-flutter/issues
 
 environment:
-  sdk: ">=2.15.1 <3.0.0"
-  flutter: ">=2.0.0"
+  sdk: ">=2.14.0 <3.0.0"
+  flutter: ">=2.5.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Goal
Allow the core `bugsnag_flutter` library to be used with Flutter 2.5.0 and higher.

## Testing
Relied on existing tests running under Flutter 2.5.0