### PR TITLE
Change the network breadcrumbs packages to require Flutter 2.5.0

### DIFF
--- a/packages/bugsnag_breadcrumbs_dart_io/pubspec.yaml
+++ b/packages/bugsnag_breadcrumbs_dart_io/pubspec.yaml
@@ -9,8 +9,8 @@ issue_tracker: https://github.com/bugsnag/bugsnag-flutter/issues
 publish_to: none
 
 environment:
-  sdk: ">=2.15.1 <3.0.0"
-  flutter: ">=2.0.0"
+  sdk: ">=2.14.0 <3.0.0"
+  flutter: ">=2.5.0"
 
 dependencies:
   flutter:

--- a/packages/bugsnag_breadcrumbs_http/pubspec.yaml
+++ b/packages/bugsnag_breadcrumbs_http/pubspec.yaml
@@ -9,8 +9,8 @@ issue_tracker: https://github.com/bugsnag/bugsnag-flutter/issues
 publish_to: none
 
 environment:
-  sdk: ">=2.15.1 <3.0.0"
-  flutter: ">=2.0.0"
+  sdk: ">=2.14.0 <3.0.0"
+  flutter: ">=2.5.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Goal
Allow `bugsnag_breadcrumbs_dart_io` and `bugsnag_breadcrumbs_http` to build and run under Flutter 2.5.0 / Dart 2.14.0

## Testing
Relied on existing tests