### PR TITLE
Log navigation context by default

### DIFF
--- a/packages/bugsnag_flutter/lib/src/breadcrumbs/navigation.dart
+++ b/packages/bugsnag_flutter/lib/src/breadcrumbs/navigation.dart
@@ -26,7 +26,7 @@ class BugsnagNavigatorObserver extends NavigatorObserver {
   /// ```
   BugsnagNavigatorObserver({
     this.leaveBreadcrumbs = true,
-    this.setContext = false,
+    this.setContext = true,
     String? navigatorName,
   }) : _navigatorName = (navigatorName != null) ? navigatorName : 'navigator';
 


### PR DESCRIPTION
## Goal
`BugsnagNavigatorObserver` should change the Event `context` by default to be inline with our over platforms.

## Testing
Relied on existing tests