### PR TITLE
Avoid reporting -1 column number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## TBD
+
+- Column numbers will be captured as `null` instead of `-1` when they're not available
+  []()
+
 ## 2.0.2 (2022-05-30)
 
 - Prefixed all class named with 'Bugsnag' to avoid clashing with application code.

--- a/packages/bugsnag_flutter/lib/src/model/stackframe.dart
+++ b/packages/bugsnag_flutter/lib/src/model/stackframe.dart
@@ -98,7 +98,7 @@ class BugsnagStackframe {
       : type = BugsnagErrorType.dart,
         file = "${frame.packageScheme}:${frame.package}/${frame.packagePath}",
         lineNumber = frame.line,
-        columnNumber = frame.column,
+        columnNumber = frame.column >= 0 ? frame.column : null,
         method = (frame.className.isNotEmpty)
             ? '${frame.className}.${frame.method}'
             : frame.method;

--- a/packages/bugsnag_flutter/test/model/stackframe_test.dart
+++ b/packages/bugsnag_flutter/test/model/stackframe_test.dart
@@ -77,12 +77,34 @@ void main() {
         final stackframe = BugsnagStackframe.fromStackFrame(f);
         expect(stackframe.file, endsWith(f.packagePath));
         expect(stackframe.lineNumber, f.line);
-        expect(stackframe.columnNumber, f.column);
+        expect(
+          stackframe.columnNumber,
+          f.column >= 0 ? equals(f.column) : isNull,
+        );
         expect(
           stackframe.method,
           f.className.isNotEmpty ? '${f.className}.${f.method}' : f.method,
         );
       }
+    });
+
+    test('null columnNumber when not available', () {
+      final stack = BugsnagStackframe.fromStackFrame(const StackFrame(
+        number: 0,
+        column: -1,
+        line: 51,
+        packageScheme: 'dart',
+        package: 'core_patch',
+        packagePath: 'object_patch.dart',
+        className: 'Object',
+        method: 'noSuchMethod',
+        source:
+            '#0   Object.noSuchMethod(dart:core_patch/object_patch.dart:51)',
+      ));
+
+      expect(stack.lineNumber, equals(51));
+      expect(stack.columnNumber, isNull);
+      expect(stack.file, equals('dart:core_patch/object_patch.dart'));
     });
   });
 }


### PR DESCRIPTION
## Goal
Don't report a column when `columnNumber`s are not available at runtime. The existing behaviour reports the sentinel `-1` values which create noise in the event reports and make reading the stack traces harder than it needs to be.

## Testing
New unit test to cover the new behaviour