### PR TITLE
Network breadcrumbs README files

### DIFF
--- a/packages/bugsnag_breadcrumbs_dart_io/README.md
+++ b/packages/bugsnag_breadcrumbs_dart_io/README.md
@@ -1,0 +1,25 @@
+# Network Breadcrumbs for Bugsnag Flutter
+
+HTTP networking breadcrumbs for [bugsnag-flutter](https://pub.dev/packages/bugsnag_flutter) when using the `dart:io` [HttpClient](https://api.flutter.dev/flutter/dart-io/HttpClient-class.html).
+If you are using the [http](https://pub.dev/packages/http) package then [bugsnag_breadcrumbs_http](https://pub.dev/packages/bugsnag_breadcrumbs_http) should be used for networking breadcrumbs.
+
+## Getting Started
+
+1. Install [bugsnag-flutter](https://pub.dev/packages/bugsnag_flutter)
+2. Add [bugsnag_breadcrumbs_dart_io](https://pub.dev/packages/bugsnag_breadcrumbs_dart_io) to your project:
+```shell
+flutter pub add bugsnag_breadcrumbs_dart_io
+```
+3. Import `bugsnag_breadcrumbs_dart_io.dart` and use `BugsnagHttpClient` instead of `HttpClient`: 
+```dart
+import 'package:bugsnag_breadcrumbs_dart_io/bugsnag_breadcrumbs_dart_io.dart';
+
+final httpClient = BugsnagHttpClient();
+final request = await client.getUrl(Uri.parse('https://example.com'));
+```
+
+## License
+
+The Bugsnag Flutter notifier is free software released under the MIT License. See
+the [LICENSE](https://github.com/bugsnag/bugsnag-flutter/blob/master/LICENSE)
+for details.

--- a/packages/bugsnag_breadcrumbs_dart_io/README.md
+++ b/packages/bugsnag_breadcrumbs_dart_io/README.md
@@ -1,11 +1,11 @@
 # Network Breadcrumbs for Bugsnag Flutter
 
-HTTP networking breadcrumbs for [bugsnag-flutter](https://pub.dev/packages/bugsnag_flutter) when using the `dart:io` [HttpClient](https://api.flutter.dev/flutter/dart-io/HttpClient-class.html).
+HTTP networking breadcrumbs for [bugsnag_flutter](https://pub.dev/packages/bugsnag_flutter) when using the `dart:io` [HttpClient](https://api.flutter.dev/flutter/dart-io/HttpClient-class.html).
 If you are using the [http](https://pub.dev/packages/http) package then [bugsnag_breadcrumbs_http](https://pub.dev/packages/bugsnag_breadcrumbs_http) should be used for networking breadcrumbs.
 
 ## Getting Started
 
-1. Install [bugsnag-flutter](https://pub.dev/packages/bugsnag_flutter)
+1. Install [bugsnag_flutter](https://pub.dev/packages/bugsnag_flutter)
 2. Add [bugsnag_breadcrumbs_dart_io](https://pub.dev/packages/bugsnag_breadcrumbs_dart_io) to your project:
 ```shell
 flutter pub add bugsnag_breadcrumbs_dart_io

--- a/packages/bugsnag_breadcrumbs_http/README.md
+++ b/packages/bugsnag_breadcrumbs_http/README.md
@@ -1,10 +1,11 @@
 # Network Breadcrumbs for Bugsnag Flutter
 
-[http](https://pub.dev/packages/http) networking breadcrumbs for [bugsnag-flutter](https://pub.dev/packages/bugsnag_flutter).
+[http](https://pub.dev/packages/http) networking breadcrumbs for [bugsnag_flutter](https://pub.dev/packages/bugsnag_flutter).
+If you are using the [HttpClient](https://api.flutter.dev/flutter/dart-io/HttpClient-class.html) class in `dart:io` then [bugsnag_breadcrumbs_dart_io](https://pub.dev/packages/bugsnag_breadcrumbs_dart_io) should be used for networking breadcrumbs.
 
 ## Getting Started
 
-1. Install [bugsnag-flutter](https://pub.dev/packages/bugsnag_flutter)
+1. Install [bugsnag_flutter](https://pub.dev/packages/bugsnag_flutter)
 2. Add [bugsnag_breadcrumbs_http](https://pub.dev/packages/bugsnag_breadcrumbs_http) to your project:
 ```shell
 flutter pub add bugsnag_breadcrumbs_http

--- a/packages/bugsnag_breadcrumbs_http/README.md
+++ b/packages/bugsnag_breadcrumbs_http/README.md
@@ -1,0 +1,25 @@
+# Network Breadcrumbs for Bugsnag Flutter
+
+[http](https://pub.dev/packages/http) networking breadcrumbs for [bugsnag-flutter](https://pub.dev/packages/bugsnag_flutter).
+
+## Getting Started
+
+1. Install [bugsnag-flutter](https://pub.dev/packages/bugsnag_flutter)
+2. Add [bugsnag_breadcrumbs_http](https://pub.dev/packages/bugsnag_breadcrumbs_http) to your project:
+```shell
+flutter pub add bugsnag_breadcrumbs_http
+```
+3. Replace references to the `http` package with `bugsnag_breadcrumbs_http`:
+```dart
+import 'package:bugsnag_breadcrumbs_http/bugsnag_breadcrumbs_http.dart' as http;
+```
+4. Use as normal, and your network breadcrumbs will be automatically logged:
+```dart
+await http.get(Uri.parse('https://example.com'));
+```
+
+## License
+
+The Bugsnag Flutter notifier is free software released under the MIT License. See
+the [LICENSE](https://github.com/bugsnag/bugsnag-flutter/blob/master/LICENSE)
+for details.


### PR DESCRIPTION
## Goal
Include `README.md` files for the new network breadcrumbs packages. These packages will appear independently from our main `bugsnag_flutter` package on pub.dev, and should explain what they're used for in their README files.