### PR TITLE
Bump bugsnag-android to v5.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## TBD
+
+- Update bugsnag-android from v5.22.1 to [v5.23.0](https://github.com/bugsnag/bugsnag-android/blob/master/CHANGELOG.md#5230-2022-06-20)
+
 ## 2.1.0 (2022-06-14)
 
 - Networking breadcrumbs can now be easily captured by using the `bugsnag_breadcrumbs_http` or `bugsnag_breadcrumbs_dart_io` packages

--- a/packages/bugsnag_flutter/android/build.gradle
+++ b/packages/bugsnag_flutter/android/build.gradle
@@ -42,6 +42,6 @@ android {
 }
 
 dependencies {
-    implementation 'com.bugsnag:bugsnag-android:5.22.1'
+    implementation 'com.bugsnag:bugsnag-android:5.23.0'
     testImplementation 'junit:junit:4.12'
 }


### PR DESCRIPTION
## Goal

Bump bugsnag-android dependency to v5.23.0

Note - this includes a new configuration option that needs to be added to the Unity codebase.

### Enhancements

* Added configuration option to control whether internal errors are sent to Bugsnag
  [#1701](https://github.com/bugsnag/bugsnag-android/pull/1701)

### Bug fixes

* Fixed Bugsnag interactions with the Google ANR handler on newer versions of Android
  [#1699](https://github.com/bugsnag/bugsnag-android/pull/1699)
* Overwriting & clearing event metadata in the NDK plugin will no longer leave phantom values
  [#1700](https://github.com/bugsnag/bugsnag-android/pull/1700)
* Improved `app.inForeground` reporting for NDK errors
  [#1690](https://github.com/bugsnag/bugsnag-android/pull/1690)
* Fixed concurrency bug that could be triggered via the React Native plugin
  [#1679](https://github.com/bugsnag/bugsnag-android/pull/1679)
* Correctly report `device.locationStatus` on Android 12 onwards using `LocationManager.isLocationEnabled`
  [1683](https://github.com/bugsnag/bugsnag-android/pull/1683)
* Fixed NDK stack-traces for libraries linked after `Bugsnag.start` was called
  [#1671](https://github.com/bugsnag/bugsnag-android/pull/1671)