### PR TITLE
[PLAT-8383] Configure `bugsnag_flutter` from native layer

### DIFF
--- a/examples/native/android/app/src/main/java/com/example/bugsnag/flutter/android/ExampleApp.kt
+++ b/examples/native/android/app/src/main/java/com/example/bugsnag/flutter/android/ExampleApp.kt
@@ -2,6 +2,7 @@ package com.example.bugsnag.flutter.android
 
 import android.app.Application
 import com.bugsnag.android.Bugsnag
+import com.bugsnag.flutter.BugsnagFlutterConfiguration
 
 class ExampleApp : Application() {
     override fun onCreate() {
@@ -9,5 +10,8 @@ class ExampleApp : Application() {
 
         // Start Bugsnag Android SDK
         Bugsnag.start(this)
+
+        // Uncomment to disable automatic detection of Dart errors:
+        // BugsnagFlutterConfiguration.enabledErrorTypes.dartErrors = false
     }
 }

--- a/examples/native/ios/BugsnagFlutter/AppDelegate.swift
+++ b/examples/native/ios/BugsnagFlutter/AppDelegate.swift
@@ -17,6 +17,9 @@ class AppDelegate: FlutterAppDelegate {
         // Start Bugsnag iOS SDK
         Bugsnag.start()
         
+        // Uncomment to disable automatic detection of Dart errors:
+        // BugsnagFlutterConfiguration.enabledErrorTypes.dartErrors = false
+        
         // Runs the default Dart entrypoint with a default Flutter route.
         flutterEngine.run();
         

--- a/features/attach_flutter.feature
+++ b/features/attach_flutter.feature
@@ -6,8 +6,8 @@ Feature: Attach to running native Bugsnag instance
     Then I wait to receive an error
     And the error is valid for the error reporting API version "4.0" for the "Flutter Bugsnag Notifier" notifier
     And the exception "errorClass" equals "_Exception"
+    And the exception "message" equals "Handled exception with attached info"
     And the error payload field "events.0.unhandled" is false
-    And the error payload field "events.0.exceptions.0.message" equals "Exception with attached info"
     And the error payload field "events.0.threads" is a non-empty array
     And the event "severity" equals "warning"
 
@@ -18,3 +18,24 @@ Feature: Attach to running native Bugsnag instance
     And the event "context" equals "flutter-test-context"
     And event 0 contains the feature flag "demo-mode" with no variant
     And event 0 contains the feature flag "sample-group" with variant "123"
+
+  Scenario: attach with an unhandled exception
+    When I run "AttachBugsnagScenario"
+    Then I wait to receive an error
+    And the error is valid for the error reporting API version "4.0" for the "Flutter Bugsnag Notifier" notifier
+    And the exception "errorClass" equals "_Exception"
+    And the exception "message" equals "Unhandled exception with attached info"
+    And the error payload field "events.0.threads" is a non-empty array
+    And the event "context" equals "flutter-test-context"
+    And the event "severity" equals "error"
+    And the event "unhandled" is true
+    And the event "user.email" is null
+    And the event "user.id" equals "test-user-id"
+    And the event "user.name" equals "Old Man Tables"
+    And event 0 contains the feature flag "demo-mode" with no variant
+    And event 0 contains the feature flag "sample-group" with variant "123"
+
+  Scenario: attach with Dart error detection disabled
+    When I configure the app to run in the "disableDartErrors" state
+    And I run "AttachBugsnagScenario"
+    Then I should receive no errors

--- a/features/fixtures/app/android/app/src/main/java/com/bugsnag/flutter/test/app/MazeRunnerMethodCallHandler.java
+++ b/features/fixtures/app/android/app/src/main/java/com/bugsnag/flutter/test/app/MazeRunnerMethodCallHandler.java
@@ -11,6 +11,7 @@ import androidx.annotation.Nullable;
 import com.bugsnag.android.Bugsnag;
 import com.bugsnag.android.Configuration;
 import com.bugsnag.android.EndpointConfiguration;
+import com.bugsnag.flutter.BugsnagFlutterConfiguration;
 import com.bugsnag.flutter.test.app.scenario.Scenario;
 
 import java.io.BufferedReader;
@@ -47,13 +48,21 @@ public class MazeRunnerMethodCallHandler implements MethodChannel.MethodCallHand
         } else if (call.method.equals("startBugsnag")) {
             Configuration config = Configuration.load(context);
             config.setApiKey("abc12312312312312312312312312312");
-            if (call.hasArgument("notifyEndpoint") && call.hasArgument("sessionEndpoint")) {
-                config.setEndpoints(new EndpointConfiguration(
-                        call.argument("notifyEndpoint"),
-                        call.argument("sessionEndpoint")
-                ));
+
+            String notifyEndpoint = call.argument("notifyEndpoint");
+            String sessionEndpoint = call.argument("sessionEndpoint");
+            String extraConfig = call.argument("extraConfig");
+
+            if (notifyEndpoint != null && sessionEndpoint != null) {
+                config.setEndpoints(new EndpointConfiguration(notifyEndpoint, sessionEndpoint));
             }
+
             Bugsnag.start(context, config);
+
+            if (extraConfig != null && extraConfig.contains("disableDartErrors")) {
+                BugsnagFlutterConfiguration.enabledErrorTypes.dartErrors = false;
+            }
+
             result.success(null);
         } else if (call.method.equals("clearPersistentData")) {
             clearPersistentData();

--- a/features/fixtures/app/ios/Runner/AppDelegate.m
+++ b/features/fixtures/app/ios/Runner/AppDelegate.m
@@ -1,4 +1,5 @@
 #import <Bugsnag/Bugsnag.h>
+#import <bugsnag_flutter/BugsnagFlutterConfiguration.h>
 
 #import "AppDelegate.h"
 #import "GeneratedPluginRegistrant.h"
@@ -51,6 +52,7 @@
         
         NSString *notifyEndpoint = call.arguments[@"notifyEndpoint"];
         NSString *sessionEndpoint = call.arguments[@"sessionEndpoint"];
+        NSString *extraConfig = call.arguments[@"extraConfig"];
         
         if(notifyEndpoint != nil && sessionEndpoint != nil) {
             config.endpoints = [[BugsnagEndpointConfiguration alloc] initWithNotify:notifyEndpoint
@@ -58,6 +60,11 @@
         }
         
         [Bugsnag startWithConfiguration:config];
+        
+        if ([extraConfig containsString:@"disableDartErrors"]) {
+            BugsnagFlutterConfiguration.enabledErrorTypes.dartErrors = NO;
+        }
+        
         result(nil);
     } else if ([@"clearPersistentData" isEqual:call.method]) {
         [NSUserDefaults.standardUserDefaults removePersistentDomainForName:NSBundle.mainBundle.bundleIdentifier];

--- a/features/fixtures/app/lib/channels.dart
+++ b/features/fixtures/app/lib/channels.dart
@@ -17,14 +17,16 @@ class MazeRunnerChannels {
   static Future<void> runScenario(String scenarioName, {String? extraConfig}) {
     return platform.invokeMethod("runScenario", {
       'scenarioName': scenarioName,
-      'extraConfig': extraConfig,
+      if (extraConfig != null) 'extraConfig': extraConfig,
     });
   }
 
-  static Future<void> startBugsnag(BugsnagEndpointConfiguration endpoints) {
+  static Future<void> startBugsnag(BugsnagEndpointConfiguration endpoints,
+      {String? extraConfig}) {
     return platform.invokeMethod("startBugsnag", {
       'notifyEndpoint': endpoints.notify,
       'sessionEndpoint': endpoints.sessions,
+      if (extraConfig != null) 'extraConfig': extraConfig,
     });
   }
 }

--- a/features/fixtures/app/lib/scenarios/attach_bugsnag_scenario.dart
+++ b/features/fixtures/app/lib/scenarios/attach_bugsnag_scenario.dart
@@ -18,11 +18,11 @@ class AttachBugsnagScenario extends Scenario {
 
         if (extraConfig?.contains("handled") == true) {
           await bugsnag.notify(
-            Exception('Exception with attached info'),
+            Exception('Handled exception with attached info'),
             StackTrace.current,
           );
         } else {
-          throw Exception('Exception with attached info');
+          throw Exception('Unhandled exception with attached info');
         }
       },
     );

--- a/features/fixtures/app/lib/scenarios/scenario.dart
+++ b/features/fixtures/app/lib/scenarios/scenario.dart
@@ -16,7 +16,7 @@ abstract class Scenario {
   }
 
   Future<void> startNativeNotifier() =>
-      MazeRunnerChannels.startBugsnag(endpoints);
+      MazeRunnerChannels.startBugsnag(endpoints, extraConfig: extraConfig);
 
   Future<void> startBugsnag() => bugsnag.start(endpoints: endpoints);
 

--- a/packages/bugsnag_flutter/android/src/main/java/com/bugsnag/flutter/BugsnagFlutter.java
+++ b/packages/bugsnag_flutter/android/src/main/java/com/bugsnag/flutter/BugsnagFlutter.java
@@ -52,14 +52,21 @@ class BugsnagFlutter {
 
     Context context;
 
-    Void attach(@NonNull JSONObject args) throws Exception {
+    JSONObject attach(@NonNull JSONObject args) throws Exception {
         if (isAttached) {
             throw new IllegalStateException("bugsnag.attach() may not be called more than once");
         }
 
+        JSONObject result = new JSONObject()
+                .put("config", new JSONObject()
+                        .put("enabledErrorTypes", new JSONObject()
+                                .put("dartErrors", BugsnagFlutterConfiguration.enabledErrorTypes.dartErrors)
+                        )
+                );
+
         if (isAnyAttached) {
             Log.i("BugsnagFlutter", "bugsnag.attach() was called from a previous Flutter context. Ignoring.");
-            return null;
+            return result;
         }
 
         Client nativeClient = InternalHooks.getClient();
@@ -78,7 +85,7 @@ class BugsnagFlutter {
 
         isAnyAttached = true;
         isAttached = true;
-        return null;
+        return result;
     }
 
     Void start(@NonNull JSONObject args) throws Exception {

--- a/packages/bugsnag_flutter/android/src/main/java/com/bugsnag/flutter/BugsnagFlutterConfiguration.java
+++ b/packages/bugsnag_flutter/android/src/main/java/com/bugsnag/flutter/BugsnagFlutterConfiguration.java
@@ -1,0 +1,5 @@
+package com.bugsnag.flutter;
+
+public class BugsnagFlutterConfiguration {
+    public static BugsnagFlutterEnabledErrorTypes enabledErrorTypes = new BugsnagFlutterEnabledErrorTypes();
+}

--- a/packages/bugsnag_flutter/android/src/main/java/com/bugsnag/flutter/BugsnagFlutterEnabledErrorTypes.java
+++ b/packages/bugsnag_flutter/android/src/main/java/com/bugsnag/flutter/BugsnagFlutterEnabledErrorTypes.java
@@ -1,0 +1,5 @@
+package com.bugsnag.flutter;
+
+public class BugsnagFlutterEnabledErrorTypes {
+    public Boolean dartErrors = true;
+}

--- a/packages/bugsnag_flutter/ios/Classes/BugsnagFlutterConfiguration.h
+++ b/packages/bugsnag_flutter/ios/Classes/BugsnagFlutterConfiguration.h
@@ -1,0 +1,7 @@
+#import "BugsnagFlutterEnabledErrorTypes.h"
+
+@interface BugsnagFlutterConfiguration : NSObject
+
+@property (class, readonly, nonnull) BugsnagFlutterEnabledErrorTypes *enabledErrorTypes;
+
+@end

--- a/packages/bugsnag_flutter/ios/Classes/BugsnagFlutterConfiguration.m
+++ b/packages/bugsnag_flutter/ios/Classes/BugsnagFlutterConfiguration.m
@@ -1,0 +1,15 @@
+#import "BugsnagFlutterConfiguration.h"
+
+@implementation BugsnagFlutterConfiguration
+
+static BugsnagFlutterEnabledErrorTypes *enabledErrorTypes;
+
++ (void)initialize {
+    enabledErrorTypes = [[BugsnagFlutterEnabledErrorTypes alloc] init];
+}
+
++ (BugsnagFlutterEnabledErrorTypes *)enabledErrorTypes {
+    return enabledErrorTypes;
+}
+
+@end

--- a/packages/bugsnag_flutter/ios/Classes/BugsnagFlutterEnabledErrorTypes.h
+++ b/packages/bugsnag_flutter/ios/Classes/BugsnagFlutterEnabledErrorTypes.h
@@ -1,0 +1,7 @@
+#import <Foundation/Foundation.h>
+
+@interface BugsnagFlutterEnabledErrorTypes : NSObject
+
+@property (nonatomic) BOOL dartErrors;
+
+@end

--- a/packages/bugsnag_flutter/ios/Classes/BugsnagFlutterEnabledErrorTypes.m
+++ b/packages/bugsnag_flutter/ios/Classes/BugsnagFlutterEnabledErrorTypes.m
@@ -1,0 +1,12 @@
+#import "BugsnagFlutterEnabledErrorTypes.h"
+
+@implementation BugsnagFlutterEnabledErrorTypes
+
+- (instancetype)init {
+    if ((self = [super init])) {
+        _dartErrors = YES;
+    }
+    return self;
+}
+
+@end

--- a/packages/bugsnag_flutter/ios/Classes/BugsnagFlutterPlugin.h
+++ b/packages/bugsnag_flutter/ios/Classes/BugsnagFlutterPlugin.h
@@ -1,40 +1,6 @@
 #import <Flutter/Flutter.h>
 
-/// Declares the methods exposed to Flutter
-@protocol BugsnagFlutterProtocol
-
-- (void)setUser:(NSDictionary *)json;
-- (NSDictionary *)getUser:(NSDictionary *)json;
-
-- (void)setContext:(NSDictionary *)json;
-- (NSString *)getContext:(NSDictionary *)json;
-
-- (void)leaveBreadcrumb:(NSDictionary *)arguments;
-- (NSArray<NSDictionary *> *)getBreadcrumbs:(NSDictionary *)arguments;
-
-- (void)addFeatureFlags:(NSArray *)featureFlags;
-- (void)clearFeatureFlag:(NSDictionary *)arguments;
-- (void)clearFeatureFlags:(NSDictionary *)arguments;
-
-- (void)addMetadata:(NSDictionary *)arguments;
-- (void)clearMetadata:(NSDictionary *)arguments;
-- (NSDictionary *)getMetadata:(NSDictionary *)arguments;
-
-- (void)attach:(NSDictionary *)json;
-
-- (void)start:(NSDictionary *)arguments;
-
-- (void)startSession:(NSDictionary *)arguments;
-- (void)pauseSession:(NSDictionary *)arguments;
-- (NSNumber *)resumeSession:(NSDictionary *)arguments;
-
-- (void)markLaunchCompleted:(NSDictionary *)arguments;
-- (NSDictionary *)getLastRunInfo:(NSDictionary *)arguments;
-
-- (NSDictionary *)createEvent:(NSDictionary *)json;
-- (void)deliverEvent:(NSDictionary *)json;
-
-@end
+#import "BugsnagFlutterProtocol.h"
 
 @interface BugsnagFlutterPlugin : NSObject<FlutterPlugin, BugsnagFlutterProtocol>
 

--- a/packages/bugsnag_flutter/ios/Classes/BugsnagFlutterPlugin.m
+++ b/packages/bugsnag_flutter/ios/Classes/BugsnagFlutterPlugin.m
@@ -8,6 +8,7 @@
 #import "BugsnagConfiguration+Private.h"
 #import "BugsnagError+Private.h"
 #import "BugsnagEvent+Private.h"
+#import "BugsnagFlutterConfiguration.h"
 #import "BugsnagHandledState.h"
 #import "BugsnagNotifier.h"
 #import "BugsnagSessionTracker.h"
@@ -209,15 +210,23 @@ static NSString *NSStringOrNil(id value) {
     return [Bugsnag getMetadataFromSection:arguments[@"section"]];
 }
 
-- (void)attach:(NSDictionary *)arguments {
+- (NSDictionary *)attach:(NSDictionary *)arguments {
     if (self.isAttached) {
         [NSException raise:NSInternalInconsistencyException format:@"bugsnag.attach() may not be called more than once"];
     }
     
+    NSDictionary *result = @{
+        @"config": @{
+            @"enabledErrorTypes": @{
+                @"dartErrors": BugsnagFlutterConfiguration.enabledErrorTypes.dartErrors ? @YES : @NO
+            }
+        }
+    };
+    
     static BOOL isAnyAttached;
     if (isAnyAttached) {
         NSLog(@"bugsnag.attach() was called from a previous Flutter context. Ignoring.");
-        return;
+        return result;
     }
     
     if (!Bugsnag.client) {
@@ -233,6 +242,7 @@ static NSString *NSStringOrNil(id value) {
     
     isAnyAttached = YES;
     self.attached = YES;
+    return result;
 }
 
 - (void)start:(NSDictionary *)arguments {

--- a/packages/bugsnag_flutter/ios/Classes/BugsnagFlutterProtocol.h
+++ b/packages/bugsnag_flutter/ios/Classes/BugsnagFlutterProtocol.h
@@ -19,7 +19,7 @@
 - (void)clearMetadata:(NSDictionary *)arguments;
 - (NSDictionary *)getMetadata:(NSDictionary *)arguments;
 
-- (void)attach:(NSDictionary *)json;
+- (NSDictionary *)attach:(NSDictionary *)json;
 
 - (void)start:(NSDictionary *)arguments;
 

--- a/packages/bugsnag_flutter/ios/Classes/BugsnagFlutterProtocol.h
+++ b/packages/bugsnag_flutter/ios/Classes/BugsnagFlutterProtocol.h
@@ -1,0 +1,36 @@
+#import <Foundation/Foundation.h>
+
+@protocol BugsnagFlutterProtocol
+
+- (void)setUser:(NSDictionary *)json;
+- (NSDictionary *)getUser:(NSDictionary *)json;
+
+- (void)setContext:(NSDictionary *)json;
+- (NSString *)getContext:(NSDictionary *)json;
+
+- (void)leaveBreadcrumb:(NSDictionary *)arguments;
+- (NSArray<NSDictionary *> *)getBreadcrumbs:(NSDictionary *)arguments;
+
+- (void)addFeatureFlags:(NSArray *)featureFlags;
+- (void)clearFeatureFlag:(NSDictionary *)arguments;
+- (void)clearFeatureFlags:(NSDictionary *)arguments;
+
+- (void)addMetadata:(NSDictionary *)arguments;
+- (void)clearMetadata:(NSDictionary *)arguments;
+- (NSDictionary *)getMetadata:(NSDictionary *)arguments;
+
+- (void)attach:(NSDictionary *)json;
+
+- (void)start:(NSDictionary *)arguments;
+
+- (void)startSession:(NSDictionary *)arguments;
+- (void)pauseSession:(NSDictionary *)arguments;
+- (NSNumber *)resumeSession:(NSDictionary *)arguments;
+
+- (void)markLaunchCompleted:(NSDictionary *)arguments;
+- (NSDictionary *)getLastRunInfo:(NSDictionary *)arguments;
+
+- (NSDictionary *)createEvent:(NSDictionary *)json;
+- (void)deliverEvent:(NSDictionary *)json;
+
+@end

--- a/packages/bugsnag_flutter/lib/src/client.dart
+++ b/packages/bugsnag_flutter/lib/src/client.dart
@@ -607,18 +607,20 @@ class Bugsnag extends BugsnagClient with DelegateClient {
   /// - [addOnError]
   Future<void> attach({
     FutureOr<void> Function()? runApp,
-    bool autoDetectErrors = true,
     List<BugsnagOnErrorCallback> onError = const [],
   }) async {
     // make sure we can use Channels before calling runApp
     _runWithErrorDetection(
-      autoDetectErrors,
+      true,
       () => WidgetsFlutterBinding.ensureInitialized(),
     );
 
-    await ChannelClient._channel.invokeMethod('attach', {
+    final result = await ChannelClient._channel.invokeMethod('attach', {
       'notifier': _notifier,
     });
+
+    final autoDetectErrors =
+        result['config']['enabledErrorTypes']['dartErrors'] as bool;
 
     final client = ChannelClient(autoDetectErrors);
     client._onErrorCallbacks.addAll(onError);

--- a/packages/bugsnag_flutter/test/bugsnag_test.dart
+++ b/packages/bugsnag_flutter/test/bugsnag_test.dart
@@ -12,7 +12,11 @@ void main() {
     });
 
     test('attach', () async {
-      channel.results['attach'] = true;
+      channel.results['attach'] = {
+        'config': {
+          'enabledErrorTypes': {'dartErrors': true}
+        }
+      };
 
       await bugsnag.attach();
 
@@ -20,7 +24,11 @@ void main() {
     });
 
     test('runApp catches async exceptions', () async {
-      channel.results['attach'] = true;
+      channel.results['attach'] = {
+        'config': {
+          'enabledErrorTypes': {'dartErrors': true}
+        }
+      };
       channel.results['createEvent'] = null;
 
       await bugsnag.attach(runApp: () async {


### PR DESCRIPTION
## Goal

Allow the native layer of apps to configure whether `bugsnag_flutter` should automatically detect unhandled Dart errors.

Builds on top of https://github.com/bugsnag/bugsnag-flutter/pull/144

## Changeset

Adds `BugsnagFlutterConfiguration` and `BugsnagFlutterEnabledErrorTypes` classes.

The Flutter plugin's `attach` method returns a JSON representation of the configuration, which `bugsnag.attach` then examines to determine whether `autoDetectErrors` should be enabled.

## Testing

Adds an E2E scenario to verify that setting `BugsnagFlutterConfiguration.enabledErrorTypes.dartErrors = false` disables automatic detection.