### PR TITLE
Bump bugsnag-android to v5.23.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## TBD
 
-- Update bugsnag-android from v5.22.1 to [v5.23.0](https://github.com/bugsnag/bugsnag-android/blob/master/CHANGELOG.md#5230-2022-06-20)
+- Update bugsnag-android from v5.22.1 to [v5.23.1](https://github.com/bugsnag/bugsnag-android/blob/master/CHANGELOG.md#5231-2022-06-23)
 - Update bugsnag-cocoa from v6.16.8 to [v6.18.1](https://github.com/bugsnag/bugsnag-cocoa/blob/master/CHANGELOG.md#6181-2022-06-22)
 
 ## 2.1.0 (2022-06-14)

--- a/packages/bugsnag_flutter/android/build.gradle
+++ b/packages/bugsnag_flutter/android/build.gradle
@@ -42,6 +42,6 @@ android {
 }
 
 dependencies {
-    implementation 'com.bugsnag:bugsnag-android:5.23.0'
+    implementation 'com.bugsnag:bugsnag-android:5.23.1'
     testImplementation 'junit:junit:4.12'
 }


### PR DESCRIPTION
### Bug fixes

* Report the correct filename for native-libs that are loaded from within apk files
  [#1705](https://github.com/bugsnag/bugsnag-android/pull/1705)