### PR TITLE
Bump bugsnag-android to v5.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## TBD
+
+- Update bugsnag-android from v5.23.1 to [v5.24.0](https://github.com/bugsnag/bugsnag-android/blob/master/CHANGELOG.md#5240-2022-06-30)
+
 ## 2.1.1 (2022-06-28)
 
 - Added `BugsnagFlutterConfiguration` to allow `bugsnag.attach` behaviour to be configured from native code.

--- a/packages/bugsnag_flutter/android/build.gradle
+++ b/packages/bugsnag_flutter/android/build.gradle
@@ -42,6 +42,6 @@ android {
 }
 
 dependencies {
-    implementation 'com.bugsnag:bugsnag-android:5.23.1'
+    implementation 'com.bugsnag:bugsnag-android:5.24.0'
     testImplementation 'junit:junit:4.12'
 }


### PR DESCRIPTION
### Enhancements

* Complex metadata (nested structures such as maps & lists) added in Java/Kotlin is now fully preserved in NDK errors
  [#1715](https://github.com/bugsnag/bugsnag-android/pull/1715)
* Configuration.discardClasses now applies to NDK errors
  [#1710](https://github.com/bugsnag/bugsnag-android/pull/1710)