### PR TITLE
Fix the unchecked-cast warnings in BugsnagFlutter

### DIFF
--- a/packages/bugsnag_flutter/android/build.gradle
+++ b/packages/bugsnag_flutter/android/build.gradle
@@ -39,9 +39,19 @@ android {
             initWith debug
         }
     }
+
+    lintOptions {
+        warningsAsErrors true
+    }
 }
 
 dependencies {
     implementation 'com.bugsnag:bugsnag-android:5.24.0'
     testImplementation 'junit:junit:4.12'
+}
+
+gradle.projectsEvaluated {
+    tasks.withType(JavaCompile) {
+        options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"
+    }
 }

--- a/packages/bugsnag_flutter/android/src/main/java/com/bugsnag/flutter/BugsnagFlutter.java
+++ b/packages/bugsnag_flutter/android/src/main/java/com/bugsnag/flutter/BugsnagFlutter.java
@@ -28,8 +28,8 @@ import org.json.JSONObject;
 
 import java.io.File;
 import java.util.Collections;
-import java.util.LinkedHashSet;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -340,6 +340,7 @@ class BugsnagFlutter {
                 .put("crashedDuringLaunch", lastRunInfo.getCrashedDuringLaunch());
     }
 
+    @SuppressWarnings("unchecked")
     JSONObject createEvent(@Nullable JSONObject args) throws JSONException {
         if (args == null) {
             return null;


### PR DESCRIPTION
## Goal
Fix the unchecked-cast warnings in BugsnagFlutter.java

## Changeset

* Suppress the warnings (the unchecked cast is expected in this case)
* Treat compiler warnings as errors so that builds should fail in cases like this in future

## Testing
Manually checked for the warning