### PR TITLE
Use `-[BugsnagMetadata copy]` instead of `-deepCopy`

### DIFF
--- a/packages/bugsnag_flutter/ios/Classes/BugsnagFlutterPlugin.m
+++ b/packages/bugsnag_flutter/ios/Classes/BugsnagFlutterPlugin.m
@@ -417,7 +417,7 @@ static NSString *NSStringOrNil(id value) {
                                                handledState:[BugsnagHandledState handledStateWithSeverityReason:
                                                              [json[@"unhandled"] boolValue] ? UnhandledException : HandledException]
                                                        user:client.user
-                                                   metadata:[client.metadata deepCopy]
+                                                   metadata:[client.metadata copy]
                                                 breadcrumbs:client.breadcrumbs.breadcrumbs ?: @[]
                                                      errors:@[error]
                                                     threads:@[]


### PR DESCRIPTION
## Goal

Remove use of `-[BugsnagMetadata deepCopy]` method which is [being removed](https://github.com/bugsnag/bugsnag-cocoa/pull/1444).

## Changeset

Uses `copy` instead of `deepCopy`.

## Testing

Verified no observable changes via existing tests.