### PR TITLE
[PLAT-8727] Allow `projectPackages` to be configured when attaching to Cocoa notifier

### DIFF
--- a/examples/native/android/app/src/main/java/com/example/bugsnag/flutter/android/ExampleApp.kt
+++ b/examples/native/android/app/src/main/java/com/example/bugsnag/flutter/android/ExampleApp.kt
@@ -2,14 +2,20 @@ package com.example.bugsnag.flutter.android
 
 import android.app.Application
 import com.bugsnag.android.Bugsnag
+import com.bugsnag.android.Configuration
 import com.bugsnag.flutter.BugsnagFlutterConfiguration
 
 class ExampleApp : Application() {
     override fun onCreate() {
         super.onCreate()
 
+        val config = Configuration.load(this)
+
+        // Add the names of Dart packages that should be displayed as "in-project" on your dashboard
+        config.projectPackages = setOf(packageName, "example_flutter")
+
         // Start Bugsnag Android SDK
-        Bugsnag.start(this)
+        Bugsnag.start(this, config)
 
         // Uncomment to disable automatic detection of Dart errors:
         // BugsnagFlutterConfiguration.enabledErrorTypes.dartErrors = false

--- a/examples/native/ios/BugsnagFlutter.xcodeproj/project.pbxproj
+++ b/examples/native/ios/BugsnagFlutter.xcodeproj/project.pbxproj
@@ -167,7 +167,7 @@
 			name = "[CP-User] Run Flutter Build example_flutter Script";
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -e\nset -u\nsource \"${SRCROOT}/../example_flutter/.ios/Flutter/flutter_export_environment.sh\"\nexport VERBOSE_SCRIPT_LOGGING=1 && \"$FLUTTER_ROOT\"/packages/flutter_tools/bin/xcode_backend.sh build\n";
+			shellScript = "set -e\nset -u\nsource \"${SRCROOT}/../example_flutter/.ios/Flutter/flutter_export_environment.sh\"\nexport VERBOSE_SCRIPT_LOGGING=1 && \"$FLUTTER_ROOT\"/packages/flutter_tools/bin/xcode_backend.sh build";
 		};
 		E89B3AC476390C585D0BE274 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/examples/native/ios/BugsnagFlutter/AppDelegate.swift
+++ b/examples/native/ios/BugsnagFlutter/AppDelegate.swift
@@ -17,6 +17,9 @@ class AppDelegate: FlutterAppDelegate {
         // Start Bugsnag iOS SDK
         Bugsnag.start()
         
+        // Specify the names of Dart packages that should be displayed as "in-project" on your dashboard.
+        BugsnagFlutterConfiguration.projectPackages = ["example_flutter"];
+        
         // Uncomment to disable automatic detection of Dart errors:
         // BugsnagFlutterConfiguration.enabledErrorTypes.dartErrors = false
         

--- a/examples/native/ios/Podfile
+++ b/examples/native/ios/Podfile
@@ -8,9 +8,6 @@ target 'BugsnagFlutter' do
   # Comment the next line if you don't want to use dynamic frameworks
   use_frameworks!
 
-  # Pods for BugsnagFlutter
-  pod 'Bugsnag'
-
   install_all_flutter_pods(flutter_application_path)
 end
 

--- a/features/fixtures/app/android/app/src/main/java/com/bugsnag/flutter/test/app/MazeRunnerMethodCallHandler.java
+++ b/features/fixtures/app/android/app/src/main/java/com/bugsnag/flutter/test/app/MazeRunnerMethodCallHandler.java
@@ -14,6 +14,8 @@ import com.bugsnag.android.EndpointConfiguration;
 import com.bugsnag.flutter.BugsnagFlutterConfiguration;
 import com.bugsnag.flutter.test.app.scenario.Scenario;
 
+import org.json.JSONException;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.InputStreamReader;
@@ -136,7 +138,7 @@ public class MazeRunnerMethodCallHandler implements MethodChannel.MethodCallHand
         if (scenario != null) {
             // we push all scenarios to the main thread to stop Flutter catching the exceptions
             mainHandler.post(() -> {
-                scenario.run(call.argument("extraConfig"));
+                scenario.run(context, call);
                 result.success(null);
             });
         }

--- a/features/fixtures/app/android/app/src/main/java/com/bugsnag/flutter/test/app/scenario/NativeCrashScenario.java
+++ b/features/fixtures/app/android/app/src/main/java/com/bugsnag/flutter/test/app/scenario/NativeCrashScenario.java
@@ -1,10 +1,12 @@
 package com.bugsnag.flutter.test.app.scenario;
 
-import androidx.annotation.Nullable;
+import android.content.Context;
+
+import io.flutter.plugin.common.MethodCall;
 
 public class NativeCrashScenario extends Scenario {
     @Override
-    public void run(@Nullable String extraConfig) {
+    public void run(Context context, MethodCall call) {
         throw new RuntimeException("crash from Java");
     }
 }

--- a/features/fixtures/app/android/app/src/main/java/com/bugsnag/flutter/test/app/scenario/NativeProjectPackagesScenario.java
+++ b/features/fixtures/app/android/app/src/main/java/com/bugsnag/flutter/test/app/scenario/NativeProjectPackagesScenario.java
@@ -1,0 +1,33 @@
+package com.bugsnag.flutter.test.app.scenario;
+
+import android.content.Context;
+
+import com.bugsnag.android.Bugsnag;
+import com.bugsnag.android.Configuration;
+import com.bugsnag.android.EndpointConfiguration;
+
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+
+import io.flutter.plugin.common.MethodCall;
+
+public class NativeProjectPackagesScenario extends Scenario {
+    @Override
+    public void run(Context context, MethodCall call) {
+
+        Configuration configuration = Configuration.load(context);
+        configuration.setApiKey("abc12312312312312312312312312312");
+        configuration.setEndpoints(new EndpointConfiguration(
+                Objects.requireNonNull(call.argument("notifyEndpoint")),
+                Objects.requireNonNull(call.argument("sessionEndpoint"))));
+
+        Set<String> projectPackages = new LinkedHashSet<>();
+        projectPackages.add("test_package");
+        projectPackages.add("MazeRunner");
+        projectPackages.add("com.bugsnag.flutter.test.app");
+        configuration.setProjectPackages(projectPackages);
+
+        Bugsnag.start(context, configuration);
+    }
+}

--- a/features/fixtures/app/android/app/src/main/java/com/bugsnag/flutter/test/app/scenario/Scenario.java
+++ b/features/fixtures/app/android/app/src/main/java/com/bugsnag/flutter/test/app/scenario/Scenario.java
@@ -1,7 +1,9 @@
 package com.bugsnag.flutter.test.app.scenario;
 
-import androidx.annotation.Nullable;
+import android.content.Context;
+
+import io.flutter.plugin.common.MethodCall;
 
 public abstract class Scenario {
-    public abstract void run(@Nullable String extraConfig);
+    public abstract void run(Context context, MethodCall call);
 }

--- a/features/fixtures/app/ios/Runner.xcodeproj/project.pbxproj
+++ b/features/fixtures/app/ios/Runner.xcodeproj/project.pbxproj
@@ -3,10 +3,11 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 50;
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0150C66A288E8EB8001ED369 /* NativeProjectPackagesScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 0150C669288E8EB8001ED369 /* NativeProjectPackagesScenario.m */; };
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		7EA36DDE163929853C78D928 /* libPods-Runner.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F4CE844D4B90BCE91B622309 /* libPods-Runner.a */; };
@@ -34,6 +35,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0150C669288E8EB8001ED369 /* NativeProjectPackagesScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NativeProjectPackagesScenario.m; sourceTree = "<group>"; };
 		089B1BCC2E63E4C0E847218F /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
@@ -84,6 +86,7 @@
 			children = (
 				96F00EF127AACC0100C218BB /* NativeCrashScenario.h */,
 				96F00EF227AACC0100C218BB /* NativeCrashScenario.m */,
+				0150C669288E8EB8001ED369 /* NativeProjectPackagesScenario.m */,
 				96E7620527A0785B00628D7B /* Scenario.h */,
 				96E7620927A18A4800628D7B /* Scenario.m */,
 			);
@@ -153,7 +156,6 @@
 				089B1BCC2E63E4C0E847218F /* Pods-Runner.release.xcconfig */,
 				30E485D6FAD8EF01A4953097 /* Pods-Runner.profile.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
@@ -288,6 +290,7 @@
 				96D8AA0B27AC3E7C0032F493 /* ffi_crashes.c in Sources */,
 				978B8F6F1D3862AE00F588F7 /* AppDelegate.m in Sources */,
 				96E7620A27A18A4800628D7B /* Scenario.m in Sources */,
+				0150C66A288E8EB8001ED369 /* NativeProjectPackagesScenario.m in Sources */,
 				97C146F31CF9000F007C117D /* main.m in Sources */,
 				1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */,
 				96F00EF327AACC0100C218BB /* NativeCrashScenario.m in Sources */,

--- a/features/fixtures/app/ios/Runner/AppDelegate.m
+++ b/features/fixtures/app/ios/Runner/AppDelegate.m
@@ -33,7 +33,6 @@
         result([self getCommand]);
     } else if([@"runScenario" isEqualToString:call.method]) {
         NSString *scenarioName = call.arguments[@"scenarioName"];
-        NSString *extraConfig = call.arguments[@"extraConfig"];
         Scenario *targetScenario = [Scenario createScenarioNamed:scenarioName];
         
         if(targetScenario == nil) {
@@ -42,7 +41,7 @@
                                        details:nil]);
         } else {
             dispatch_async(dispatch_get_main_queue(), ^{
-                [targetScenario runWithExtraConfig:extraConfig];
+                [targetScenario runWithArguments:call.arguments];
                 result(nil);
             });
         }

--- a/features/fixtures/app/ios/Runner/Info.plist
+++ b/features/fixtures/app/ios/Runner/Info.plist
@@ -55,5 +55,7 @@
 	</dict>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<true/>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 </dict>
 </plist>

--- a/features/fixtures/app/ios/Runner/Scenarios/NativeCrashScenario.m
+++ b/features/fixtures/app/ios/Runner/Scenarios/NativeCrashScenario.m
@@ -3,7 +3,7 @@
 
 @implementation NativeCrashScenario
 
-- (void)runWithExtraConfig:(NSString *)extraConfig {
+- (void)runWithArguments:(NSDictionary *)extraConfig {
   @throw [[NSException alloc] initWithName:@"NSException" reason:@"NativeCrashScenario" userInfo:nil];
 }
 

--- a/features/fixtures/app/ios/Runner/Scenarios/NativeProjectPackagesScenario.m
+++ b/features/fixtures/app/ios/Runner/Scenarios/NativeProjectPackagesScenario.m
@@ -1,0 +1,23 @@
+#import "Scenario.h"
+
+#import <bugsnag_flutter/BugsnagFlutterConfiguration.h>
+
+@interface NativeProjectPackagesScenario : Scenario
+
+@end
+
+@implementation NativeProjectPackagesScenario
+
+- (void)runWithArguments:(NSDictionary *)arguments {
+    BugsnagConfiguration *configuration = [BugsnagConfiguration loadConfig];
+    configuration.apiKey = @"abc12312312312312312312312312312";
+    configuration.endpoints = [[BugsnagEndpointConfiguration alloc] initWithNotify:arguments[@"notifyEndpoint"]
+                                                                          sessions:arguments[@"sessionEndpoint"]];
+    [Bugsnag startWithConfiguration:configuration];
+    
+    BugsnagFlutterConfiguration.projectPackages = @[@"test_package",
+                                                    @"MazeRunner",
+                                                    @"com.bugsnag.flutter.test.app"];
+}
+
+@end

--- a/features/fixtures/app/ios/Runner/Scenarios/Scenario.h
+++ b/features/fixtures/app/ios/Runner/Scenarios/Scenario.h
@@ -13,7 +13,7 @@
 /**
  * Executes the test case
  */
-- (void)runWithExtraConfig:(NSString *)extraConfig;
+- (void)runWithArguments:(NSDictionary *)extraConfig;
 
 @end
 

--- a/features/fixtures/app/ios/Runner/Scenarios/Scenario.m
+++ b/features/fixtures/app/ios/Runner/Scenarios/Scenario.m
@@ -18,7 +18,7 @@
     return self;
 }
 
-- (void)runWithExtraConfig:(NSString *)extraConfig {
+- (void)runWithArguments:(NSString *)extraConfig {
     [self doesNotRecognizeSelector:_cmd];
 }
 

--- a/features/fixtures/app/lib/channels.dart
+++ b/features/fixtures/app/lib/channels.dart
@@ -14,12 +14,10 @@ class MazeRunnerChannels {
     return platform.invokeMethod('clearPersistentData');
   }
 
-  static Future<void> runScenario(String scenarioName, {String? extraConfig}) {
-    return platform.invokeMethod("runScenario", {
-      'scenarioName': scenarioName,
-      if (extraConfig != null) 'extraConfig': extraConfig,
-    });
-  }
+  static Future<void> runScenario(String scenarioName,
+          {Map<String, dynamic>? arguments}) async =>
+      platform.invokeMethod('runScenario',
+          Map.of(arguments ?? {})..['scenarioName'] = scenarioName);
 
   static Future<void> startBugsnag(BugsnagEndpointConfiguration endpoints,
       {String? extraConfig}) {

--- a/features/fixtures/app/lib/channels.dart
+++ b/features/fixtures/app/lib/channels.dart
@@ -16,8 +16,10 @@ class MazeRunnerChannels {
 
   static Future<void> runScenario(String scenarioName,
           {Map<String, dynamic>? arguments}) async =>
-      platform.invokeMethod('runScenario',
-          Map.of(arguments ?? {})..['scenarioName'] = scenarioName);
+      platform.invokeMethod('runScenario', {
+        'scenarioName': scenarioName,
+        ...?arguments,
+      });
 
   static Future<void> startBugsnag(BugsnagEndpointConfiguration endpoints,
       {String? extraConfig}) {

--- a/features/fixtures/app/lib/scenarios/native_project_packages_scenario.dart
+++ b/features/fixtures/app/lib/scenarios/native_project_packages_scenario.dart
@@ -6,15 +6,14 @@ import 'scenario.dart';
 class NativeProjectPackagesScenario extends Scenario {
   @override
   Future<void> run() async {
-    await MazeRunnerChannels.runScenario('NativeProjectPackagesScenario', arguments: {
-      'notifyEndpoint': endpoints.notify,
-      'sessionEndpoint': endpoints.sessions
-    });
+    await MazeRunnerChannels.runScenario('NativeProjectPackagesScenario',
+        arguments: {
+          'notifyEndpoint': endpoints.notify,
+          'sessionEndpoint': endpoints.sessions,
+        });
 
     await bugsnag.attach(
-      runApp: () async {
-        throw Exception('Keep calm and carry on');
-      },
+      runApp: () => throw Exception('Keep calm and carry on'),
     );
   }
 }

--- a/features/fixtures/app/lib/scenarios/native_project_packages_scenario.dart
+++ b/features/fixtures/app/lib/scenarios/native_project_packages_scenario.dart
@@ -1,0 +1,20 @@
+import 'package:MazeRunner/channels.dart';
+import 'package:bugsnag_flutter/bugsnag_flutter.dart';
+
+import 'scenario.dart';
+
+class NativeProjectPackagesScenario extends Scenario {
+  @override
+  Future<void> run() async {
+    await MazeRunnerChannels.runScenario('NativeProjectPackagesScenario', arguments: {
+      'notifyEndpoint': endpoints.notify,
+      'sessionEndpoint': endpoints.sessions
+    });
+
+    await bugsnag.attach(
+      runApp: () async {
+        throw Exception('Keep calm and carry on');
+      },
+    );
+  }
+}

--- a/features/fixtures/app/lib/scenarios/scenarios.dart
+++ b/features/fixtures/app/lib/scenarios/scenarios.dart
@@ -11,6 +11,7 @@ import 'last_run_info_scenario.dart';
 import 'manual_sessions_scenario.dart';
 import 'metadata_scenario.dart';
 import 'native_crash_scenario.dart';
+import 'native_project_packages_scenario.dart';
 import 'navigation_breadcrumbs_scenario.dart';
 import 'on_error_scenario.dart';
 import 'project_packages_scenario.dart';
@@ -43,6 +44,8 @@ final List<ScenarioInfo<Scenario>> scenarios = [
   ScenarioInfo('ManualSessionsScenario', () => ManualSessionsScenario()),
   ScenarioInfo('MetadataScenario', () => MetadataScenario()),
   ScenarioInfo('NativeCrashScenario', () => NativeCrashScenario()),
+  ScenarioInfo(
+      'NativeProjectPackagesScenario', () => NativeProjectPackagesScenario()),
   ScenarioInfo(
       'NavigatorBreadcrumbScenario', () => NavigatorBreadcrumbScenario()),
   ScenarioInfo('OnErrorScenario', () => OnErrorScenario()),

--- a/features/project_packages.feature
+++ b/features/project_packages.feature
@@ -11,3 +11,14 @@ Feature: projectPackages
     And the event "projectPackages.0" equals "test_package"
     And the event "projectPackages.1" equals "MazeRunner"
     And on Android, the event "projectPackages.2" equals "com.bugsnag.flutter.test.app"
+
+  Scenario: Sends projectPackages after attaching to native layer
+    When I run "NativeProjectPackagesScenario"
+    Then I wait to receive an error
+    And the error is valid for the error reporting API version "4.0" for the "Flutter Bugsnag Notifier" notifier
+    And the exception "errorClass" equals "_Exception"
+    And the exception "message" equals "Keep calm and carry on"
+    And the error payload field "events.0.projectPackages" is an array with 3 elements
+    And the event "projectPackages.0" equals "test_package"
+    And the event "projectPackages.1" equals "MazeRunner"
+    And the event "projectPackages.2" equals "com.bugsnag.flutter.test.app"

--- a/packages/bugsnag_flutter/ios/Classes/BugsnagFlutterConfiguration.h
+++ b/packages/bugsnag_flutter/ios/Classes/BugsnagFlutterConfiguration.h
@@ -4,4 +4,6 @@
 
 @property (class, readonly, nonnull) BugsnagFlutterEnabledErrorTypes *enabledErrorTypes;
 
+@property (class, copy, nullable) NSArray<NSString *> *projectPackages;
+
 @end

--- a/packages/bugsnag_flutter/ios/Classes/BugsnagFlutterConfiguration.h
+++ b/packages/bugsnag_flutter/ios/Classes/BugsnagFlutterConfiguration.h
@@ -4,6 +4,12 @@
 
 @property (class, readonly, nonnull) BugsnagFlutterEnabledErrorTypes *enabledErrorTypes;
 
+/**
+ * The (Dart) package names that Bugsnag should consider to be part of the running application.
+ * 
+ * Dart stack frames are marked as in-project if they originate from any of these packages, and
+ * this allows us to improve the visual display of the stacktrace on the dashboard.
+ */
 @property (class, copy, nullable) NSArray<NSString *> *projectPackages;
 
 @end

--- a/packages/bugsnag_flutter/ios/Classes/BugsnagFlutterConfiguration.m
+++ b/packages/bugsnag_flutter/ios/Classes/BugsnagFlutterConfiguration.m
@@ -3,6 +3,7 @@
 @implementation BugsnagFlutterConfiguration
 
 static BugsnagFlutterEnabledErrorTypes *enabledErrorTypes;
+static NSArray<NSString *> *projectPackages;
 
 + (void)initialize {
     enabledErrorTypes = [[BugsnagFlutterEnabledErrorTypes alloc] init];
@@ -10,6 +11,14 @@ static BugsnagFlutterEnabledErrorTypes *enabledErrorTypes;
 
 + (BugsnagFlutterEnabledErrorTypes *)enabledErrorTypes {
     return enabledErrorTypes;
+}
+
++ (NSArray<NSString *> *)projectPackages {
+    return projectPackages;
+}
+
++ (void)setProjectPackages:(NSArray<NSString *> *)newValue {
+    projectPackages = newValue;
 }
 
 @end

--- a/packages/bugsnag_flutter/ios/Classes/BugsnagFlutterPlugin.m
+++ b/packages/bugsnag_flutter/ios/Classes/BugsnagFlutterPlugin.m
@@ -240,6 +240,8 @@ static NSString *NSStringOrNil(id value) {
     Bugsnag.client.notifier.url = notifier[@"url"];
     Bugsnag.client.notifier.dependencies = @[[[BugsnagNotifier alloc] init]];
     
+    self.projectPackages = BugsnagFlutterConfiguration.projectPackages;
+
     isAnyAttached = YES;
     self.attached = YES;
     return result;


### PR DESCRIPTION
## Goal

Allow `projectPackages` to be configured when attaching to the Cocoa notifier

## Changeset

Adds `projectPackages` property to `BugsnagFlutterConfiguration` (for Cocoa only) and reads this in the plugin's `attach` method.

## Testing

Adds new E2E scenario to verify that events have the expected `projectPackages`.