### PR TITLE
[PLAT-8599] Add `telemetry` option (with `internalErrors`) to `bugsnag.start`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## TBD
 
+- Added `telemetry` option to `bugsnag.start` to allow sending of internal errors to be disabled.
 - Update bugsnag-android from v5.23.1 to [v5.25.0](https://github.com/bugsnag/bugsnag-android/blob/master/CHANGELOG.md#5250-2022-07-19)
 - Update bugsnag-cocoa from v6.18.1 to [v6.21.0](https://github.com/bugsnag/bugsnag-cocoa/blob/master/CHANGELOG.md#6210-2022-07-20)
 

--- a/packages/bugsnag_flutter/android/src/main/java/com/bugsnag/flutter/BugsnagFlutter.java
+++ b/packages/bugsnag_flutter/android/src/main/java/com/bugsnag/flutter/BugsnagFlutter.java
@@ -207,6 +207,10 @@ class BugsnagFlutter {
             configuration.setProjectPackages(packagesSet);
         }
 
+        if (args.has("telemetry")) {
+            configuration.setTelemetry(EnumHelper.unwrapTelemetry(args.optJSONArray("telemetry")));
+        }
+
         if (args.has("versionCode")) {
             configuration.setVersionCode(args.getInt("versionCode"));
         }

--- a/packages/bugsnag_flutter/android/src/main/java/com/bugsnag/flutter/EnumHelper.java
+++ b/packages/bugsnag_flutter/android/src/main/java/com/bugsnag/flutter/EnumHelper.java
@@ -3,6 +3,7 @@ package com.bugsnag.flutter;
 import androidx.annotation.Nullable;
 
 import com.bugsnag.android.BreadcrumbType;
+import com.bugsnag.android.Telemetry;
 
 import org.json.JSONArray;
 
@@ -17,6 +18,7 @@ import java.util.Set;
  */
 class EnumHelper {
     private static final Map<String, BreadcrumbType> dartBreadcrumbTypes = new HashMap<>();
+    private static final Map<String, Telemetry> dartTelemetry = new HashMap<>();
 
     static {
         dartBreadcrumbTypes.put("navigation", BreadcrumbType.NAVIGATION);
@@ -27,6 +29,8 @@ class EnumHelper {
         dartBreadcrumbTypes.put("state", BreadcrumbType.STATE);
         dartBreadcrumbTypes.put("error", BreadcrumbType.ERROR);
         dartBreadcrumbTypes.put("manual", BreadcrumbType.MANUAL);
+
+        dartTelemetry.put("internalErrors", Telemetry.INTERNAL_ERRORS);
     }
 
     private EnumHelper() {
@@ -41,13 +45,24 @@ class EnumHelper {
 
         int enabledTypeCount = breadcrumbTypes.length();
         for (int index = 0; index < enabledTypeCount; index++) {
-            set.add(getBreadcrumbType(breadcrumbTypes.optString(index)));
+            set.add(dartBreadcrumbTypes.get(breadcrumbTypes.optString(index)));
         }
 
         return set;
     }
 
-    static BreadcrumbType getBreadcrumbType(String breadcrumbTypeName) {
-        return dartBreadcrumbTypes.get(breadcrumbTypeName);
+    static Set<Telemetry> unwrapTelemetry(@Nullable JSONArray telemetry) {
+        if (telemetry == null) {
+            return Collections.emptySet();
+        }
+
+        Set<Telemetry> set = EnumSet.noneOf(Telemetry.class);
+
+        int count = telemetry.length();
+        for (int i = 0; i < count; i++) {
+            set.add(dartTelemetry.get(telemetry.optString(i)));
+        }
+
+        return set;
     }
 }

--- a/packages/bugsnag_flutter/ios/Classes/BugsnagFlutterPlugin.m
+++ b/packages/bugsnag_flutter/ios/Classes/BugsnagFlutterPlugin.m
@@ -379,6 +379,13 @@ static NSString *NSStringOrNil(id value) {
         self.projectPackages = projectPackages[@"packageNames"];
     }
     
+    NSArray *telemetry = arguments[@"telemetry"];
+    if ([telemetry isKindOfClass:[NSArray class]]) {
+        BSGTelemetryOptions value = 
+        ([telemetry containsObject:@"internalErrors"] ? BSGTelemetryInternalErrors : 0);
+        configuration.telemetry = value;
+    }
+    
     [Bugsnag startWithConfiguration:configuration];
     
     self.started = YES;

--- a/packages/bugsnag_flutter/lib/src/client.dart
+++ b/packages/bugsnag_flutter/lib/src/client.dart
@@ -684,6 +684,7 @@ class Bugsnag extends BugsnagClient with DelegateClient {
     Map<String, Map<String, Object>>? metadata,
     List<BugsnagFeatureFlag>? featureFlags,
     List<BugsnagOnErrorCallback> onError = const [],
+    Set<BugsnagTelemetryType>? telemetry,
     Directory? persistenceDirectory,
     int? versionCode,
   }) async {
@@ -733,6 +734,9 @@ class Bugsnag extends BugsnagClient with DelegateClient {
       if (metadata != null) 'metadata': BugsnagMetadata(metadata),
       'featureFlags': featureFlags,
       'notifier': _notifier,
+      'telemetry': (telemetry ?? BugsnagTelemetryType.values)
+          .map((e) => e.toName())
+          .toList(),
       if (persistenceDirectory != null)
         'persistenceDirectory': persistenceDirectory.absolute.path,
       if (versionCode != null) 'versionCode': versionCode,

--- a/packages/bugsnag_flutter/lib/src/config.dart
+++ b/packages/bugsnag_flutter/lib/src/config.dart
@@ -77,3 +77,10 @@ enum BugsnagEnabledBreadcrumbType {
   state,
   error,
 }
+
+/// Types of telemetry that may be sent to Bugsnag for product improvement
+/// purposes.
+enum BugsnagTelemetryType {
+  /// Errors within the Bugsnag SDK.
+  internalErrors,
+}

--- a/packages/bugsnag_flutter/test/bugsnag_test.dart
+++ b/packages/bugsnag_flutter/test/bugsnag_test.dart
@@ -70,5 +70,25 @@ void main() {
       // we should request platform default-packages by default
       expect(channel['start'][0]['projectPackages']['includeDefaults'], isTrue);
     });
+
+    test('default telemetry', () async {
+      channel.results['start'] = true;
+      await bugsnag.start();
+
+      expect(
+        channel['start'][0]['telemetry'],
+        equals(const ['internalErrors']),
+      );
+    });
+
+    test('disabled telemetry', () async {
+      channel.results['start'] = true;
+      await bugsnag.start(telemetry: {});
+
+      expect(
+        channel['start'][0]['telemetry'],
+        equals(const []),
+      );
+    });
   });
 }


### PR DESCRIPTION
## Goal

Allow Flutter apps to configure Bugsnag's telemetry option.

## Changeset

Adds `BugsnagTelemetryType` enum with a single `internalErrors` member.

Adds optional `telemetry` argument to `bugsnag.start` which defaults to all telemetry.

Updates Android and Cocoa plugins to pass telemetry options through to native layer.

## Testing

Adds unit test cases to check expected values are passed to channel.

Manually verified expected native values are configured by debugging example app.