### PR TITLE
Fix JSON error with metadata containing lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Added `telemetry` option to `bugsnag.start` to allow sending of internal errors to be disabled.
 - Update bugsnag-android from v5.23.1 to [v5.25.0](https://github.com/bugsnag/bugsnag-android/blob/master/CHANGELOG.md#5250-2022-07-19)
 - Update bugsnag-cocoa from v6.18.1 to [v6.21.0](https://github.com/bugsnag/bugsnag-cocoa/blob/master/CHANGELOG.md#6210-2022-07-20)
+- Fixed 'Unhandled Exception' in JSON encoding of metadata containing list objects
+  [#160](https://github.com/bugsnag/bugsnag-flutter/pull/160)
 
 ## 2.1.1 (2022-06-28)
 

--- a/features/breadcrumbs.feature
+++ b/features/breadcrumbs.feature
@@ -9,5 +9,10 @@ Feature: Start Bugsnag from Flutter
     And the error payload field "events.0.breadcrumbs.0.type" equals "state"
     And the error payload field "events.0.breadcrumbs.1.metaData.foo" equals "bar"
     And the error payload field "events.0.breadcrumbs.1.metaData.object.test" equals "hello"
+    And the error payload field "events.0.breadcrumbs.1.metaData.object.bool" is true
+    And the error payload field "events.0.breadcrumbs.1.metaData.object.number" equals 1234
+    And the error payload field "events.0.breadcrumbs.1.metaData.object.list.0" equals 'abc'
+    And the error payload field "events.0.breadcrumbs.1.metaData.object.list.1" equals 4321
+    And the error payload field "events.0.breadcrumbs.1.metaData.object.list.2" is true
     And the error payload field "events.0.breadcrumbs.1.name" equals "Manual breadcrumb"
     And the error payload field "events.0.breadcrumbs.1.type" equals "manual"

--- a/features/fixtures/app/lib/scenarios/breadcrumbs_scenario.dart
+++ b/features/fixtures/app/lib/scenarios/breadcrumbs_scenario.dart
@@ -11,7 +11,16 @@ class BreadcrumbsScenario extends Scenario {
 
     await bugsnag.leaveBreadcrumb('Manual breadcrumb', metadata: const {
       'foo': 'bar',
-      'object': {'test': 'hello'}
+      'object': {
+        'test': 'hello',
+        'bool': true,
+        'number': 1234,
+        'list': [
+          'abc',
+          4321,
+          true,
+        ],
+      }
     });
 
     final breadcrumbs = await bugsnag.getBreadcrumbs();

--- a/packages/bugsnag_flutter/lib/src/model/metadata.dart
+++ b/packages/bugsnag_flutter/lib/src/model/metadata.dart
@@ -55,7 +55,7 @@ class BugsnagMetadata {
     if (value is Map<String, dynamic>) return sanitizedMap(value);
     // Special case because empty Maps wil not be caught on previous line
     if (value is Map && value.isEmpty) return value;
-    if (value is Iterable) return value.map((e) => _sanitizedValue(e));
+    if (value is Iterable) return value.map((e) => _sanitizedValue(e)).toList();
     try {
       return '$value';
     } catch (e) {


### PR DESCRIPTION
## Goal
Fix 'Unexpected Exception' when encoding metadata containing `List` objects. This was caused by calling `map` in `BugsnagMetadata` without `toList()`, resulting in attempting to encode a `MappedListIterable` (which is not a `List`) when sending the metadata to the native layer.

## Testing
Added more types (list, number and boolean) to the "breadcrumbs" end to end scenario and assert they are presented as expected.