### PR TITLE
Handle 'invalid Dart instruction address' native stack frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Update bugsnag-cocoa from v6.18.1 to [v6.21.0](https://github.com/bugsnag/bugsnag-cocoa/blob/master/CHANGELOG.md#6210-2022-07-20)
 - Fixed 'Unhandled Exception' in JSON encoding of metadata containing list objects
   [#160](https://github.com/bugsnag/bugsnag-flutter/pull/160)
+- Add specific handling for 'invalid Dart instruction address' native stack frames
+  [#161](https://github.com/bugsnag/bugsnag-flutter/pull/161)
 
 ## 2.1.1 (2022-06-28)
 

--- a/packages/bugsnag_flutter/lib/src/bugsnag_stacktrace.dart
+++ b/packages/bugsnag_flutter/lib/src/bugsnag_stacktrace.dart
@@ -90,6 +90,11 @@ BugsnagStacktrace? parseNativeStackTrace(String stackTrace) {
       stacktrace.add(
         BugsnagStackframe.fromStackFrame(StackFrame.asynchronousSuspension),
       );
+    } else if (line.contains('<invalid Dart instruction address>')) {
+      stacktrace.add(BugsnagStackframe(
+        type: BugsnagErrorType.dart,
+        method: 'invalid Dart instruction address',
+      ));
     } else {
       buildId ??= _parseBuildId(line);
       baseOffset ??= _parseBaseAddress(line);

--- a/packages/bugsnag_flutter/test/bugsnag_stacktrace_test.dart
+++ b/packages/bugsnag_flutter/test/bugsnag_stacktrace_test.dart
@@ -83,6 +83,23 @@ void main() {
       );
     });
 
+    test('parses invalid instruction addresses', () {
+      final stacktrace = parseNativeStackTrace(invalidAddressStackTrace);
+
+      expect(stacktrace, isNotNull);
+      expect(stacktrace, hasLength(4));
+
+      expect(
+        stacktrace!.map((f) => f.method),
+        equals(const [
+          '_kDartIsolateSnapshotInstructions',
+          'asynchronous suspension',
+          'invalid Dart instruction address',
+          'asynchronous suspension',
+        ]),
+      );
+    });
+
     test('returns null for non-native StackTraces', () {
       final stacktrace = parseNativeStackTrace(StackTrace.current.toString());
       expect(stacktrace, isNull);
@@ -147,3 +164,15 @@ const obfuscatedStackTraceIOS =
     '    <asynchronous suspension>\n'
     '    #01 abs 000000010c1f53e3 _kDartIsolateSnapshotInstructions+0x22dba3\n'
     '    <asynchronous suspension>\n';
+
+const invalidAddressStackTrace =
+    'Warning: This VM has been configured to produce stack traces that violate the Dart standard.\n'
+    '*** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***\n'
+    'pid: 4714, tid: 4750, name 1.ui\n'
+    'build_id: \'8deece9b6a5fc3491895d61fa03e8967\'\n'
+    'isolate_dso_base: 6db6697000, vm_dso_base: 6db6697000\n'
+    'isolate_instructions: 6db677b7f0, vm_instructions: 6db6777000\n'
+    '#00 abs 0000006db69c1503 virt 000000000032a503 _kDartIsolateSnapshotInstructions+0x245d13\n'
+    '<asynchronous suspension>\n'
+    '#01 abs 0000000000000000 <invalid Dart instruction address>\n'
+    '<asynchronous suspension>\n';


### PR DESCRIPTION
## Goal
Native stack traces with 'invalid Dart instruction address' frames resulted in `"frameAddress": 0` instead of retaining their message.

## Design
Check for the 'invalid Dart instruction address' message and insert a specialised `BugsnagStackframe` in its place.

## Testing
Manual testing, and new unit tests.