### PR TITLE
[PLAT-8719] Add `BugsnagTelemetryType.usage`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## TBD
 
+- Added `BugsnagTelemetryType.usage` to allow sending of usage telemetry to be disabled.
+  [#176](https://github.com/bugsnag/bugsnag-flutter/pull/176)
 - Update bugsnag-cocoa from v6.21.0 to [v6.24.0](https://github.com/bugsnag/bugsnag-cocoa/blob/master/CHANGELOG.md#6240-2022-10-05)
 - Update bugsnag-android from v5.25.0 to [v5.28.1](https://github.com/bugsnag/bugsnag-android/blob/master/CHANGELOG.md#5281-2022-10-19)
 

--- a/packages/bugsnag_flutter/android/src/main/java/com/bugsnag/flutter/EnumHelper.java
+++ b/packages/bugsnag_flutter/android/src/main/java/com/bugsnag/flutter/EnumHelper.java
@@ -31,6 +31,7 @@ class EnumHelper {
         dartBreadcrumbTypes.put("manual", BreadcrumbType.MANUAL);
 
         dartTelemetry.put("internalErrors", Telemetry.INTERNAL_ERRORS);
+        dartTelemetry.put("usage", Telemetry.USAGE);
     }
 
     private EnumHelper() {

--- a/packages/bugsnag_flutter/ios/Classes/BugsnagFlutterPlugin.m
+++ b/packages/bugsnag_flutter/ios/Classes/BugsnagFlutterPlugin.m
@@ -370,7 +370,8 @@ static NSString *NSStringOrNil(id value) {
     NSArray *telemetry = arguments[@"telemetry"];
     if ([telemetry isKindOfClass:[NSArray class]]) {
         BSGTelemetryOptions value = 
-        ([telemetry containsObject:@"internalErrors"] ? BSGTelemetryInternalErrors : 0);
+        ([telemetry containsObject:@"internalErrors"] ? BSGTelemetryInternalErrors : 0) |
+        ([telemetry containsObject:@"usage"]          ? BSGTelemetryUsage          : 0) ;
         configuration.telemetry = value;
     }
     

--- a/packages/bugsnag_flutter/lib/src/config.dart
+++ b/packages/bugsnag_flutter/lib/src/config.dart
@@ -83,4 +83,7 @@ enum BugsnagEnabledBreadcrumbType {
 enum BugsnagTelemetryType {
   /// Errors within the Bugsnag SDK.
   internalErrors,
+
+  /// Information about how Bugsnag has been configured.
+  usage,
 }

--- a/packages/bugsnag_flutter/test/bugsnag_test.dart
+++ b/packages/bugsnag_flutter/test/bugsnag_test.dart
@@ -77,7 +77,7 @@ void main() {
 
       expect(
         channel['start'][0]['telemetry'],
-        equals(const ['internalErrors']),
+        equals(const ['internalErrors', 'usage']),
       );
     });
 


### PR DESCRIPTION
## Goal

Allow Flutter apps to configure Bugsnag's `usage` telemetry option.

## Changeset

Adds `BugsnagTelemetryType.usage`.

Updates Android and Cocoa plugins to pass `usage` telemetry options through to native layer.

## Testing

Updates unit test cases to check expected telemetry values are passed to channel.

Manually verified expected native values are configured by debugging example app.