### PR TITLE
Additional calls to attach will log a warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Added `maxStringValueLength` option to `bugsnag.start` to allow truncation behaviour to be configured.
   [#179](https://github.com/bugsnag/bugsnag-flutter/pull/179)
+- Native-first hot-reloads (using `bugnag.attach`) will no longer cause errors, but will instead emit a warning
+  [#182](https://github.com/bugsnag/bugsnag-flutter/pull/182)
 - Update bugsnag-android from v5.28.1 to [v5.28.3](https://github.com/bugsnag/bugsnag-android/blob/master/CHANGELOG.md#5283-2022-11-16)
 
 ## 2.3.0 (2022-10-27)

--- a/features/attach_flutter.feature
+++ b/features/attach_flutter.feature
@@ -39,3 +39,39 @@ Feature: Attach to running native Bugsnag instance
     When I configure the app to run in the "disableDartErrors" state
     And I run "AttachBugsnagScenario"
     Then I should receive no errors
+
+  Scenario: multiple attaches with a handled exception
+    When I configure the app to run in the "handled extra-attach" state
+    And I run "AttachBugsnagScenario"
+    Then I wait to receive 2 errors
+    And the error is valid for the error reporting API version "4.0" for the "Flutter Bugsnag Notifier" notifier
+    And the exception "errorClass" equals "_Exception"
+    And the exception "message" equals "Handled exception with attached info"
+    And the error payload field "events.0.unhandled" is false
+    And the error payload field "events.0.threads" is a non-empty array
+    And the event "severity" equals "warning"
+
+    And the event "user.id" equals "test-user-id"
+    And the event "user.email" is null
+    And the event "user.name" equals "Old Man Tables"
+
+    And the event "context" equals "flutter-test-context"
+    And event 0 contains the feature flag "demo-mode" with no variant
+    And event 0 contains the feature flag "sample-group" with variant "123"
+
+  Scenario: multiple attaches with an unhandled exception
+    When I configure the app to run in the "extra-attach" state
+    When I run "AttachBugsnagScenario"
+    Then I wait to receive 2 errors
+    And the error is valid for the error reporting API version "4.0" for the "Flutter Bugsnag Notifier" notifier
+    And the exception "errorClass" equals "_Exception"
+    And the exception "message" equals "Unhandled exception with attached info"
+    And the error payload field "events.0.threads" is a non-empty array
+    And the event "context" equals "flutter-test-context"
+    And the event "severity" equals "error"
+    And the event "unhandled" is true
+    And the event "user.email" is null
+    And the event "user.id" equals "test-user-id"
+    And the event "user.name" equals "Old Man Tables"
+    And event 0 contains the feature flag "demo-mode" with no variant
+    And event 0 contains the feature flag "sample-group" with variant "123"

--- a/features/fixtures/app/lib/scenarios/attach_bugsnag_scenario.dart
+++ b/features/fixtures/app/lib/scenarios/attach_bugsnag_scenario.dart
@@ -5,6 +5,14 @@ class AttachBugsnagScenario extends Scenario {
   @override
   Future<void> run() async {
     await startNativeNotifier();
+
+    final attachFuture = await doAttach();
+    if (extraConfig?.contains("extra-attach") == true) {
+      await doAttach();
+    }
+  }
+
+  Future<void> doAttach() async {
     await bugsnag.attach(
       runApp: () async {
         await Future.wait([

--- a/packages/bugsnag_flutter/android/src/main/java/com/bugsnag/flutter/BugsnagFlutter.java
+++ b/packages/bugsnag_flutter/android/src/main/java/com/bugsnag/flutter/BugsnagFlutter.java
@@ -37,8 +37,7 @@ class BugsnagFlutter {
 
     private InternalHooks client;
 
-    private static boolean isAnyAttached = false;
-    private boolean isAttached = false;
+    private static boolean isAttached = false;
 
     private static boolean isAnyStarted = false;
     private boolean isStarted = false;
@@ -53,10 +52,6 @@ class BugsnagFlutter {
     Context context;
 
     JSONObject attach(@NonNull JSONObject args) throws Exception {
-        if (isAttached) {
-            throw new IllegalStateException("bugsnag.attach() may not be called more than once");
-        }
-
         JSONObject result = new JSONObject()
                 .put("config", new JSONObject()
                         .put("enabledErrorTypes", new JSONObject()
@@ -64,8 +59,8 @@ class BugsnagFlutter {
                         )
                 );
 
-        if (isAnyAttached) {
-            Log.i("BugsnagFlutter", "bugsnag.attach() was called from a previous Flutter context. Ignoring.");
+        if (isAttached) {
+            Log.i("BugsnagFlutter", "bugsnag.attach() has already been called. Ignoring.");
             return result;
         }
 
@@ -83,7 +78,6 @@ class BugsnagFlutter {
         notifier.setUrl(notifierJson.getString("url"));
         notifier.setDependencies(Collections.singletonList(new Notifier()));
 
-        isAnyAttached = true;
         isAttached = true;
         return result;
     }

--- a/packages/bugsnag_flutter/ios/Classes/BugsnagFlutterPlugin.m
+++ b/packages/bugsnag_flutter/ios/Classes/BugsnagFlutterPlugin.m
@@ -67,7 +67,6 @@ static NSString *NSStringOrNil(id value) {
 
 @interface BugsnagFlutterPlugin ()
 
-@property (nonatomic, getter=isAttached) BOOL attached;
 @property (nonatomic, getter=isStarted) BOOL started;
 @property (nullable, nonatomic) NSArray *projectPackages;
 
@@ -207,10 +206,6 @@ static NSString *NSStringOrNil(id value) {
 }
 
 - (NSDictionary *)attach:(NSDictionary *)arguments {
-    if (self.isAttached) {
-        [NSException raise:NSInternalInconsistencyException format:@"bugsnag.attach() may not be called more than once"];
-    }
-    
     NSDictionary *result = @{
         @"config": @{
             @"enabledErrorTypes": @{
@@ -219,9 +214,9 @@ static NSString *NSStringOrNil(id value) {
         }
     };
     
-    static BOOL isAnyAttached;
-    if (isAnyAttached) {
-        NSLog(@"bugsnag.attach() was called from a previous Flutter context. Ignoring.");
+    static BOOL isAttached;
+    if (isAttached) {
+        NSLog(@"bugsnag.attach() has already been called. Ignoring.");
         return result;
     }
     
@@ -238,8 +233,7 @@ static NSString *NSStringOrNil(id value) {
     
     self.projectPackages = BugsnagFlutterConfiguration.projectPackages;
 
-    isAnyAttached = YES;
-    self.attached = YES;
+    isAttached = YES;
     return result;
 }
 


### PR DESCRIPTION
## Goal
Improve hot-reload experience when using `bugsnag.attach` by not throwing an error.

## Design
Emit a warning message, instead of throwing an exception when `attach` has already been called.

## Testing
New end to end scenarios were added to check that additional calls to `attach` do not cause startup failures.