### PR TITLE
StateError fix in _createEvent method in client.dart

### DIFF
--- a/packages/bugsnag_flutter/lib/src/client.dart
+++ b/packages/bugsnag_flutter/lib/src/client.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'dart:ui';
 
 import 'package:bugsnag_flutter/src/error_factory.dart';
+import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';

--- a/packages/bugsnag_flutter/lib/src/client.dart
+++ b/packages/bugsnag_flutter/lib/src/client.dart
@@ -523,7 +523,7 @@ class ChannelClient implements BugsnagClient {
     required bool unhandled,
     required bool deliver,
   }) async {
-    final buildID = error.stacktrace.first.codeIdentifier;
+    final buildID = error.stacktrace.firstOrNull.codeIdentifier;
     final errorInfo = details?.informationCollector?.call() ?? [];
     final errorContext = details?.context?.toDescription();
     final errorLibrary = details?.library;

--- a/packages/bugsnag_flutter/lib/src/client.dart
+++ b/packages/bugsnag_flutter/lib/src/client.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:io';
-import 'dart:ui';
 
 import 'package:bugsnag_flutter/src/error_factory.dart';
 import 'package:collection/collection.dart';
@@ -524,7 +523,7 @@ class ChannelClient implements BugsnagClient {
     required bool unhandled,
     required bool deliver,
   }) async {
-    final buildID = error.stacktrace.firstOrNull.codeIdentifier;
+    final buildID = error.stacktrace.firstOrNull?.codeIdentifier;
     final errorInfo = details?.informationCollector?.call() ?? [];
     final errorContext = details?.context?.toDescription();
     final errorLibrary = details?.library;


### PR DESCRIPTION
## Goal

<!-- Why is this change necessary? -->
StateErrors were being thrown from calling .first on an empty list in the method `Future<BugsnagEvent?> _createEvent(`.
## Design

<!-- Why was this approach used? -->
`buildID` is nullable anyway. bugsnag probably expected it'd be null because it's null on the first element of `error.stacktrace` instead of from `error.stacktrace` being empty. If you all want to fix it a different way, that's fine. This PR can just help point out what's wrong.
Also, if you don't want the import for `'package:collection/collection.dart';`, you can change it something else like
```
final String? buildID;
if (error.stacktrace.isNotEmpty)  {
  buildID = error.stacktrace.first.codeIdentifier;
}
```

## Changeset

<!-- What changed? -->
I used a method from collection.dart that doesn't cause StateErrors when trying to get the first element of a List. Because that method can return null, I added `?` before `.codeIdentifier`. Also I removed `import 'dart:ui';` because it was unused.
## Testing

<!-- How was it tested? What manual and automated tests were
     run/added? -->
I tested throwing deliberate errors in my app locally and saw that they were successfully reported to bugsnag. Then I switched my production app to using my forked copy of the bugsnag_flutter repo.