### PR TITLE
Prevent crash with empty stack trace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Update bugsnag-cocoa from v6.25.0 to [v6.26.2](https://github.com/bugsnag/bugsnag-cocoa/blob/master/CHANGELOG.md#6262-2023-04-20)
 - Update bugsnag-android from v5.28.3 to [v5.30.0](https://github.com/bugsnag/bugsnag-android/blob/master/CHANGELOG.md#5300-2023-05-11)
+- Prevent crashing if the stack trace is empty
+  [#204](https://github.com/bugsnag/bugsnag-flutter/pull/204)
 
 ## 2.4.0 (2022-12-01)
 

--- a/packages/bugsnag_flutter/lib/src/bugsnag_stacktrace.dart
+++ b/packages/bugsnag_flutter/lib/src/bugsnag_stacktrace.dart
@@ -67,9 +67,11 @@ int? _parseBaseAddress(String line) {
 
 BugsnagStacktrace? _parseStackTrace(String stackTraceString) {
   try {
-    return StackFrame.fromStackTrace(StackTrace.fromString(stackTraceString))
-        .map((frame) => BugsnagStackframe.fromStackFrame(frame))
-        .toList();
+    final stackTrace =
+        StackFrame.fromStackTrace(StackTrace.fromString(stackTraceString))
+            .map((frame) => BugsnagStackframe.fromStackFrame(frame))
+            .toList();
+    return stackTrace.isEmpty ? null : stackTrace;
   } catch (e) {
     return null;
   }

--- a/packages/bugsnag_flutter/lib/src/client.dart
+++ b/packages/bugsnag_flutter/lib/src/client.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:bugsnag_flutter/src/error_factory.dart';
-import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
@@ -523,7 +522,9 @@ class ChannelClient implements BugsnagClient {
     required bool unhandled,
     required bool deliver,
   }) async {
-    final buildID = error.stacktrace.firstOrNull?.codeIdentifier;
+    final buildID = error.stacktrace.isNotEmpty
+        ? error.stacktrace.first.codeIdentifier
+        : null;
     final errorInfo = details?.informationCollector?.call() ?? [];
     final errorContext = details?.context?.toDescription();
     final errorLibrary = details?.library;

--- a/packages/bugsnag_flutter/lib/src/client.dart
+++ b/packages/bugsnag_flutter/lib/src/client.dart
@@ -1,8 +1,8 @@
 import 'dart:async';
 import 'dart:io';
-import 'dart:ui';
 
 import 'package:bugsnag_flutter/src/error_factory.dart';
+import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
@@ -523,7 +523,7 @@ class ChannelClient implements BugsnagClient {
     required bool unhandled,
     required bool deliver,
   }) async {
-    final buildID = error.stacktrace.first.codeIdentifier;
+    final buildID = error.stacktrace.firstOrNull?.codeIdentifier;
     final errorInfo = details?.informationCollector?.call() ?? [];
     final errorContext = details?.context?.toDescription();
     final errorLibrary = details?.library;

--- a/packages/bugsnag_flutter/lib/src/client.dart
+++ b/packages/bugsnag_flutter/lib/src/client.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:io';
+import 'dart:ui';
 
 import 'package:bugsnag_flutter/src/error_factory.dart';
 import 'package:flutter/foundation.dart';

--- a/packages/bugsnag_flutter/test/error_factory_test.dart
+++ b/packages/bugsnag_flutter/test/error_factory_test.dart
@@ -16,6 +16,17 @@ void main() {
       expect(error.stacktrace.length, greaterThan(3));
     });
 
+    test('Empty stack trace', () {
+      final error = BugsnagErrorFactory.instance
+          .createError(Exception('this is a message'), StackTrace.empty);
+
+      expect(error.type, equals(BugsnagErrorType.dart));
+      // a surprise _ appears!
+      expect(error.errorClass, equals('_Exception'));
+      expect(error.message, equals('this is a message'));
+      expect(error.stacktrace.length, greaterThan(0));
+    });
+
     test('Exception with an object message', () {
       final error = BugsnagErrorFactory.instance.createError(Exception(main));
 


### PR DESCRIPTION
## Goal

Closes #186

## Design

If the error has a stack trace but the stacktrace is empty, we should use the fallback stack trace instead of an empty list.

If the stacktrace is empty, we shouldn't crash by calling `.first`.