### PR TITLE
Serialize enum metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Update bugsnag-android from v5.28.3 to [v5.30.0](https://github.com/bugsnag/bugsnag-android/blob/master/CHANGELOG.md#5300-2023-05-11)
 - Prevent crashing if the stack trace is empty
   [#204](https://github.com/bugsnag/bugsnag-flutter/pull/204)
+- Include breadcrumb metadata in sanitizing (allows enums in metadata)
+  [#206](https://github.com/bugsnag/bugsnag-flutter/pull/206)
 
 ## 2.4.0 (2022-12-01)
 

--- a/packages/bugsnag_flutter/lib/src/model/breadcrumbs.dart
+++ b/packages/bugsnag_flutter/lib/src/model/breadcrumbs.dart
@@ -9,10 +9,11 @@ class BugsnagBreadcrumb {
 
   final DateTime timestamp;
 
-  BugsnagBreadcrumb(this.message,
-      {this.type = BugsnagBreadcrumbType.manual, Map<String, Object>? metadata})
-      : timestamp = DateTime.now().toUtc(),
-        metadata = BugsnagMetadata.sanitizedMap(metadata ?? {});
+  BugsnagBreadcrumb(
+    this.message, {
+    this.type = BugsnagBreadcrumbType.manual,
+    this.metadata,
+  }) : timestamp = DateTime.now().toUtc();
 
   BugsnagBreadcrumb.fromJson(Map<String, dynamic> json)
       : message = json.safeGet('name'),
@@ -26,7 +27,7 @@ class BugsnagBreadcrumb {
         'name': message,
         'type': type.toName(),
         'timestamp': timestamp.toIso8601String(),
-        'metaData': metadata ?? {},
+        'metaData': BugsnagMetadata.sanitizedMap(metadata ?? {}),
       };
 }
 

--- a/packages/bugsnag_flutter/lib/src/model/breadcrumbs.dart
+++ b/packages/bugsnag_flutter/lib/src/model/breadcrumbs.dart
@@ -9,12 +9,10 @@ class BugsnagBreadcrumb {
 
   final DateTime timestamp;
 
-  BugsnagBreadcrumb(
-    this.message, {
-    this.type = BugsnagBreadcrumbType.manual,
-    metadata = MetadataMap,
-  })  : timestamp = DateTime.now().toUtc(),
-        metadata = BugsnagMetadata.sanitizedMap(metadata);
+  BugsnagBreadcrumb(this.message,
+      {this.type = BugsnagBreadcrumbType.manual, Map<String, Object>? metadata})
+      : timestamp = DateTime.now().toUtc(),
+        metadata = BugsnagMetadata.sanitizedMap(metadata ?? {});
 
   BugsnagBreadcrumb.fromJson(Map<String, dynamic> json)
       : message = json.safeGet('name'),

--- a/packages/bugsnag_flutter/lib/src/model/breadcrumbs.dart
+++ b/packages/bugsnag_flutter/lib/src/model/breadcrumbs.dart
@@ -12,8 +12,9 @@ class BugsnagBreadcrumb {
   BugsnagBreadcrumb(
     this.message, {
     this.type = BugsnagBreadcrumbType.manual,
-    this.metadata,
-  }) : timestamp = DateTime.now().toUtc();
+    metadata = MetadataMap,
+  })  : timestamp = DateTime.now().toUtc(),
+        metadata = BugsnagMetadata.sanitizedMap(metadata);
 
   BugsnagBreadcrumb.fromJson(Map<String, dynamic> json)
       : message = json.safeGet('name'),

--- a/packages/bugsnag_flutter/test/channel_client_test.dart
+++ b/packages/bugsnag_flutter/test/channel_client_test.dart
@@ -17,6 +17,7 @@ void main() {
         'attach': true,
         'createEvent': _mockCreateEvent,
         'deliverEvent': null,
+        'addMetadata': null,
       });
     });
 
@@ -123,6 +124,37 @@ void main() {
         expect(value, isNull);
         expect(channel['createEvent'], hasLength(1));
         expect(channel['createEvent'][0]['deliver'], isTrue);
+      });
+
+      test('Metadata is sanitized', () async {
+        final sampleMetadata = {
+          "List": [1, 2, 3],
+          "Enum": BugsnagBreadcrumbType.manual,
+          "Map": Map<String, Object>.from({"1": 2}),
+        };
+
+        client.addMetadata("Hello", sampleMetadata);
+
+        expect(channel['addMetadata'], hasLength(1));
+        final actualMetadata = channel['addMetadata'][0]['metadata'];
+        expect(actualMetadata["List"], equals([1, 2, 3]));
+        expect(actualMetadata["Enum"], equals("BugsnagBreadcrumbType.manual"));
+        expect(actualMetadata["Map"], equals({"1": 2}));
+      });
+
+      test('Breadcrumb metadata is sanitized', () async {
+        final sampleMetadata = {
+          "List": [1, 2, 3],
+          "Enum": BugsnagBreadcrumbType.manual,
+          "Map": Map<String, Object>.from({"1": 2}),
+        };
+        final breadcrumb = BugsnagBreadcrumb("Hello",
+            type: BugsnagBreadcrumbType.manual, metadata: sampleMetadata);
+
+        expect(breadcrumb.metadata?["List"], equals([1, 2, 3]));
+        expect(breadcrumb.metadata?["Enum"],
+            equals("BugsnagBreadcrumbType.manual"));
+        expect(breadcrumb.metadata?["Map"], equals({"1": 2}));
       });
     });
   });

--- a/packages/bugsnag_flutter/test/channel_client_test.dart
+++ b/packages/bugsnag_flutter/test/channel_client_test.dart
@@ -142,19 +142,21 @@ void main() {
         expect(actualMetadata["Map"], equals({"1": 2}));
       });
 
-      test('Breadcrumb metadata is sanitized', () async {
+      test('Breadcrumb metadata json roundtrip', () async {
         final sampleMetadata = {
           "List": [1, 2, 3],
           "Enum": BugsnagBreadcrumbType.manual,
           "Map": Map<String, Object>.from({"1": 2}),
         };
-        final breadcrumb = BugsnagBreadcrumb("Hello",
-            type: BugsnagBreadcrumbType.manual, metadata: sampleMetadata);
+        final json = BugsnagBreadcrumb("Hello",
+                type: BugsnagBreadcrumbType.manual, metadata: sampleMetadata)
+            .toJson();
+        final decoded = BugsnagBreadcrumb.fromJson(json);
 
-        expect(breadcrumb.metadata?["List"], equals([1, 2, 3]));
-        expect(breadcrumb.metadata?["Enum"],
-            equals("BugsnagBreadcrumbType.manual"));
-        expect(breadcrumb.metadata?["Map"], equals({"1": 2}));
+        expect(decoded.metadata?["List"], equals([1, 2, 3]));
+        expect(
+            decoded.metadata?["Enum"], equals("BugsnagBreadcrumbType.manual"));
+        expect(decoded.metadata?["Map"], equals({"1": 2}));
       });
     });
   });


### PR DESCRIPTION
## Goal

Closes #198

## Design

The metadata is now always sanitised, meaning that all enums are converted to strings.

## Testing

Test added to ensure that different data types are properly sanitised when passed as metadata.