### PR TITLE
Telemetry API change

### DIFF
--- a/packages/bugsnag_flutter/lib/src/client.dart
+++ b/packages/bugsnag_flutter/lib/src/client.dart
@@ -685,7 +685,7 @@ class Bugsnag extends BugsnagClient with DelegateClient {
     Map<String, Map<String, Object>>? metadata,
     List<BugsnagFeatureFlag>? featureFlags,
     List<BugsnagOnErrorCallback> onError = const [],
-    Set<BugsnagTelemetryType>? telemetry,
+    BugsnagTelemetryTypes telemetry = BugsnagTelemetryTypes.all,
     Directory? persistenceDirectory,
     int? versionCode,
   }) async {
@@ -736,9 +736,7 @@ class Bugsnag extends BugsnagClient with DelegateClient {
       if (metadata != null) 'metadata': BugsnagMetadata(metadata),
       'featureFlags': featureFlags,
       'notifier': _notifier,
-      'telemetry': (telemetry ?? BugsnagTelemetryType.values)
-          .map((e) => e.toName())
-          .toList(),
+      'telemetry': telemetry.toList(),
       if (persistenceDirectory != null)
         'persistenceDirectory': persistenceDirectory.absolute.path,
       if (versionCode != null) 'versionCode': versionCode,

--- a/packages/bugsnag_flutter/lib/src/config.dart
+++ b/packages/bugsnag_flutter/lib/src/config.dart
@@ -80,10 +80,25 @@ enum BugsnagEnabledBreadcrumbType {
 
 /// Types of telemetry that may be sent to Bugsnag for product improvement
 /// purposes.
-enum BugsnagTelemetryType {
+class BugsnagTelemetryTypes {
   /// Errors within the Bugsnag SDK.
-  internalErrors,
+  final bool internalErrors;
 
   /// Information about how Bugsnag has been configured.
-  usage,
+  final bool usage;
+
+  const BugsnagTelemetryTypes({
+    this.internalErrors = true,
+    this.usage = true,
+  });
+
+  dynamic toJson() => {
+        'internalErrors': internalErrors,
+        'usage': usage,
+      };
+
+  dynamic toList() =>
+      [if (internalErrors) "internalErrors", if (usage) "usage"];
+
+  static const BugsnagTelemetryTypes all = BugsnagTelemetryTypes();
 }

--- a/packages/bugsnag_flutter/test/bugsnag_test.dart
+++ b/packages/bugsnag_flutter/test/bugsnag_test.dart
@@ -81,9 +81,22 @@ void main() {
       );
     });
 
+    test('disabled internal errors only', () async {
+      channel.results['start'] = true;
+      await bugsnag.start(
+          telemetry: const BugsnagTelemetryTypes(internalErrors: false));
+
+      expect(
+        channel['start'][0]['telemetry'],
+        equals(const ["usage"]),
+      );
+    });
+
     test('disabled telemetry', () async {
       channel.results['start'] = true;
-      await bugsnag.start(telemetry: {});
+      await bugsnag.start(
+          telemetry:
+              const BugsnagTelemetryTypes(internalErrors: false, usage: false));
 
       expect(
         channel['start'][0]['telemetry'],


### PR DESCRIPTION
## Goal

Improve disabling only one telemetry option

## Design

To disable only one telemetry type, the following code can be used:
```dart
await bugsnag.start(
    telemetry: const BugsnagTelemetryTypes(internalErrors: false));
```

## Testing

Add test to ensure that only the correct telemetry types are set.