### PR TITLE
Automatically update references to dependencies

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -1,0 +1,66 @@
+name: update-dependencies
+
+on:
+  repository_dispatch:
+    types: [update-dependency]
+  workflow_dispatch:
+    inputs:
+      target_submodule:
+        description: 'Submodule to update'
+        required: true
+        type: string
+      target_version:
+        description: 'Version of the submodule to update to'
+        required: true
+        type: string
+
+jobs:
+  update-dependencies:
+    runs-on: ubuntu-latest
+    env:
+      SUBMODULE: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.target_submodule || inputs.target_submodule }}
+      VERSION: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.target_version || inputs.target_version }}
+      BUNDLE_GITHUB__COM: ${{ secrets.BUNDLE_ACCESS_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: next
+
+      - run: |
+          git config --global user.name 'Bumpsnag bot'
+          git config --global user.email ''
+
+      - run: git fetch --prune --unshallow
+
+      - name: Install libcurl4-openssl-dev and net-tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install libcurl4-openssl-dev net-tools
+
+      - name: Install ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+
+      - name: Install dependencies
+        run: bundle install
+
+      - name: Update references locally
+        run: make update-bugsnag-dependency
+
+      - name: Commit and push changes
+        run: bundle exec bumpsnag commit_update $SUBMODULE $VERSION
+
+      - name: List current branch name
+        id: current-branch
+        run: echo "branch=$(git rev-parse --abbrev-ref HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Create pull request
+        if: ${{ steps.current-branch.outputs.branch != 'next'}}
+        run: >
+         gh pr create -B next
+         -H bumpsnag-$TARGET_SUBMODULE-$TARGET_VERSION
+         --title "Update $TARGET_SUBMODULE to version $TARGET_VERSION"
+         --body 'Created by bumpsnag'
+         --reviewer kstenerud

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   update-dependencies:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     env:
       SUBMODULE: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.target_submodule || inputs.target_submodule }}
       VERSION: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.target_version || inputs.target_version }}

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -63,4 +63,4 @@ jobs:
          -H bumpsnag-$TARGET_SUBMODULE-$TARGET_VERSION
          --title "Update $TARGET_SUBMODULE to version $TARGET_VERSION"
          --body 'Created by bumpsnag'
-         --reviewer kstenerud
+         --reviewer kstenerud,robert-smartbear

--- a/Gemfile
+++ b/Gemfile
@@ -9,3 +9,8 @@ gem 'bugsnag-maze-runner', '~> 8.0'
 
 # Locally, you can run against Maze Runner branches and uncommitted changes:
 #gem 'bugsnag-maze-runner', path: '../maze-runner'
+
+# Only install bumpsnag if we're using Github actions
+unless ENV['GITHUB_ACTIONS'].nil?
+  gem 'bumpsnag', git: 'https://github.com/bugsnag/platforms-bumpsnag', branch: 'main'
+end

--- a/Makefile
+++ b/Makefile
@@ -88,3 +88,27 @@ e2e_ios_local: features/fixtures/app/build/ios/ipa/app.ipa
 
 features/fixtures/app/build/ios/ipa/app.ipa: $(shell find packages/bugsnag_flutter features/fixtures/app/ios/Runner features/fixtures/app/lib -type f)
 	cd features/fixtures/app && $(FLUTTER_BIN) build ipa --export-options-plist=ios/exportOptions.plist
+
+update-bugsnag-android:
+ifeq ($(VERSION),)
+	@$(error VERSION is not defined. Run with `make VERSION=number update-bugsnag-android`)
+endif
+	sed -i '' "s/'com.bugsnag:bugsnag-android:.*'/'com.bugsnag:bugsnag-android:$(VERSION)'/" packages/bugsnag_flutter/android/build.gradle
+
+update-bugsnag-cocoa:
+ifeq ($(VERSION),)
+	@$(error VERSION is not defined. Run with `make VERSION=number update-bugsnag-cocoa`)
+endif
+	sed -i '' "s/s.dependency 'Bugsnag', '.*'/s.dependency 'Bugsnag', '$(VERSION)'/" packages/bugsnag_flutter/ios/bugsnag_flutter.podspec
+
+update-bugsnag-dependency:
+ifeq ($(SUBMODULE),)
+	@$(error SUBMODULE is not defined. Run with `make SUBMODULE=target update-bugsnag-dependency`)
+endif
+ifeq ($(SUBMODULE), bugsnag-android)
+	$(MAKE) update-bugsnag-android
+else ifeq ($(SUBMODULE), bugsnag-cocoa)
+	$(MAKE) update-bugsnag-cocoa
+else
+	@$(error SUBMODULE must be one of bugsnag-android or bugsnag-cocoa)
+endif


### PR DESCRIPTION
## Goal

Adds a github actions workflow to receive messages from upstream repos (bugsnag-android and bugsnag-cocoa) when a new release is made, updating those versions in appropriate places, committing the changes, then pushing and PRing the resulting branch.

## Testing

Since this is based off of the similar unity pipeline, that represents a test setup for this workflow.  Functions such as those in the makefile have all been run locally.