### PR TITLE
bump bugsnag android to 3.31.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## TBD
 
 - Update bugsnag-cocoa from v6.26.2 to [v6.28.0](https://github.com/bugsnag/bugsnag-cocoa/blob/master/CHANGELOG.md#6280-2023-12-13)
+- Update bugsnag-android from v5.30.0 to [v5.31.3](https://github.com/bugsnag/bugsnag-android/blob/master/CHANGELOG.md#5313-2023-11-06)
+
 
 ## 3.0.0 (2023-07-19)
 

--- a/packages/bugsnag_flutter/android/build.gradle
+++ b/packages/bugsnag_flutter/android/build.gradle
@@ -50,7 +50,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.bugsnag:bugsnag-android:5.30.0'
+    implementation 'com.bugsnag:bugsnag-android:5.31.3'
     testImplementation 'junit:junit:4.12'
 }
 


### PR DESCRIPTION
- Update bugsnag-android from v5.30.0 to [v5.31.3](https://github.com/bugsnag/bugsnag-android/blob/master/CHANGELOG.md#5313-2023-11-06)
