### PR TITLE
Remove unnecessary net tools addition, which doesn't function on MacOS

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -33,11 +33,6 @@ jobs:
 
       - run: git fetch --prune --unshallow
 
-      - name: Install libcurl4-openssl-dev and net-tools
-        run: |
-          sudo apt-get update
-          sudo apt-get install libcurl4-openssl-dev net-tools
-
       - name: Install ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
## Goal

This both isn't required, and causes the action to fail on MacOS.