### PR TITLE
PLAT-11617 change http dep to be less strict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## TBD
+- Change the bugsnag_breadcrumbs_http http dependancy to ">=0.13.4" so that there are less strict version requirements [#235](https://github.com/bugsnag/bugsnag-flutter/pull/235)
 
 - Update bugsnag-cocoa from v6.26.2 to [v6.28.0](https://github.com/bugsnag/bugsnag-cocoa/blob/master/CHANGELOG.md#6280-2023-12-13)
 - Update bugsnag-android from v5.30.0 to [v5.31.3](https://github.com/bugsnag/bugsnag-android/blob/master/CHANGELOG.md#5313-2023-11-06)

--- a/packages/bugsnag_breadcrumbs_http/pubspec.yaml
+++ b/packages/bugsnag_breadcrumbs_http/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
     sdk: flutter
   bugsnag_flutter:
     path: ../bugsnag_flutter
-  http: ^0.13.4
+  http: ">=0.13.4"
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Goal

This change allows users to use whatever version of the http lib they like.

## Testing

Covered by existing tests