### PR TITLE
Improved the behaviour on Android when Bugsnag is started multiple times from different contexts

### DIFF
--- a/packages/bugsnag_flutter/android/src/main/java/com/bugsnag/flutter/BugsnagFlutter.java
+++ b/packages/bugsnag_flutter/android/src/main/java/com/bugsnag/flutter/BugsnagFlutter.java
@@ -91,7 +91,8 @@ class BugsnagFlutter {
         }
 
         if (isAnyStarted) {
-            Log.i("BugsnagFlutter", "bugsnag.start() was called from a previous Flutter context. Ignoring.");
+            Log.w("BugsnagFlutter", "bugsnag.start() was called from a previous Flutter context. Reusing existing client. Config not applied.");
+            client = new InternalHooks(InternalHooks.getClient());
             return null;
         }
 


### PR DESCRIPTION
## Goal

This change allows events to be reported after start (instead of attach) is called from a new Flutter context after Flutter has already started

## Design

A previously initialized client is reused by the new context (without any changes in its configuration)