### PR TITLE
Bump bugsnag-android to v6. Changed redactedKeys and discardClasses types to RegExp

### DIFF
--- a/features/fixtures/app/lib/scenarios/discard_classes_scenario.dart
+++ b/features/fixtures/app/lib/scenarios/discard_classes_scenario.dart
@@ -9,9 +9,9 @@ class DiscardClassesScenario extends Scenario {
 
     await bugsnag.start(
       endpoints: endpoints,
-      discardClasses: const {
-        '_Exception',
-      }
+      discardClasses: {
+        RegExp('_Exception'),
+      },
     );
     try {
       throw Exception('this should be discarded');

--- a/features/fixtures/app/lib/scenarios/start_bugsnag_scenario.dart
+++ b/features/fixtures/app/lib/scenarios/start_bugsnag_scenario.dart
@@ -6,33 +6,32 @@ class StartBugsnagScenario extends Scenario {
   @override
   Future<void> run() async {
     await bugsnag.start(
-      apiKey: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-      appType: 'test',
-      appVersion: '1.2.3',
-      versionCode: 4321,
-      context: 'awesome',
-      user: BugsnagUser(
-        id: '123',
-        name: 'From Config',
-      ),
-      redactedKeys: {'secret'},
-      releaseStage: 'testing',
-      enabledReleaseStages: {'testing'},
-      enabledBreadcrumbTypes: {BugsnagEnabledBreadcrumbType.error},
-      endpoints: endpoints,
-      featureFlags: const [
-        BugsnagFeatureFlag('demo-mode'),
-        BugsnagFeatureFlag('sample-group', '123'),
-      ],
-      metadata: const {
-        'custom': {
-          'foo': 'bar',
-          'secret': 'should be hidden',
-          'password': 'not redacted'
-        }
-      },
-      sendThreads: BugsnagThreadSendPolicy.never
-    );
+        apiKey: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        appType: 'test',
+        appVersion: '1.2.3',
+        versionCode: 4321,
+        context: 'awesome',
+        user: BugsnagUser(
+          id: '123',
+          name: 'From Config',
+        ),
+        redactedKeys: {RegExp('secret')},
+        releaseStage: 'testing',
+        enabledReleaseStages: {'testing'},
+        enabledBreadcrumbTypes: {BugsnagEnabledBreadcrumbType.error},
+        endpoints: endpoints,
+        featureFlags: const [
+          BugsnagFeatureFlag('demo-mode'),
+          BugsnagFeatureFlag('sample-group', '123'),
+        ],
+        metadata: const {
+          'custom': {
+            'foo': 'bar',
+            'secret': 'should be hidden',
+            'password': 'not redacted'
+          }
+        },
+        sendThreads: BugsnagThreadSendPolicy.never);
     await bugsnag.notify(
       Exception('Exception with attached info'),
       StackTrace.current,

--- a/features/fixtures/app/lib/scenarios/start_bugsnag_scenario.dart
+++ b/features/fixtures/app/lib/scenarios/start_bugsnag_scenario.dart
@@ -31,7 +31,8 @@ class StartBugsnagScenario extends Scenario {
             'password': 'not redacted'
           }
         },
-        sendThreads: BugsnagThreadSendPolicy.never);
+        sendThreads: BugsnagThreadSendPolicy.never,
+      );
     await bugsnag.notify(
       Exception('Exception with attached info'),
       StackTrace.current,

--- a/packages/bugsnag_flutter/android/build.gradle
+++ b/packages/bugsnag_flutter/android/build.gradle
@@ -50,7 +50,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.bugsnag:bugsnag-android:5.31.3'
+    implementation 'com.bugsnag:bugsnag-android:6.6.0'
     testImplementation 'junit:junit:4.12'
 }
 

--- a/packages/bugsnag_flutter/android/src/main/java/com/bugsnag/flutter/BugsnagFlutter.java
+++ b/packages/bugsnag_flutter/android/src/main/java/com/bugsnag/flutter/BugsnagFlutter.java
@@ -32,6 +32,7 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 class BugsnagFlutter {
 
@@ -120,11 +121,11 @@ class BugsnagFlutter {
         configuration.setPersistUser(arguments.optBoolean("persistUser", configuration.getPersistUser()));
 
         if (arguments.has("redactedKeys")) {
-            configuration.setRedactedKeys(unwrap(arguments.optJSONArray("redactedKeys"), new HashSet<>()));
+            configuration.setRedactedKeys(regexSetFromArray(arguments.optJSONArray("redactedKeys")));
         }
 
         if (arguments.has("discardClasses")) {
-            configuration.setDiscardClasses(unwrap(arguments.optJSONArray("discardClasses"), new HashSet<>()));
+            configuration.setDiscardClasses(regexSetFromArray(arguments.optJSONArray("discardClasses")));
         }
 
         if (arguments.has("enabledReleaseStages")) {
@@ -342,6 +343,15 @@ class BugsnagFlutter {
     Void markLaunchCompleted(@Nullable Void args) {
         Bugsnag.markLaunchCompleted();
         return null;
+    }
+
+    HashSet<Pattern> regexSetFromArray(JSONArray array) {
+        HashSet<String> originalSet = unwrap(array, new HashSet<String>());
+        HashSet<Pattern> result = new HashSet<>();
+        for(String element: originalSet) {
+            result.add(Pattern.compile(element));
+        }
+        return result;
     }
 
     JSONObject getLastRunInfo(@Nullable Void args) throws JSONException {

--- a/packages/bugsnag_flutter/android/src/main/java/com/bugsnag/flutter/BugsnagFlutter.java
+++ b/packages/bugsnag_flutter/android/src/main/java/com/bugsnag/flutter/BugsnagFlutter.java
@@ -345,11 +345,25 @@ class BugsnagFlutter {
         return null;
     }
 
-    HashSet<Pattern> regexSetFromArray(JSONArray array) {
-        HashSet<String> originalSet = unwrap(array, new HashSet<String>());
-        HashSet<Pattern> result = new HashSet<>();
-        for(String element: originalSet) {
-            result.add(Pattern.compile(element));
+    Set<Pattern> regexSetFromArray(JSONArray array) throws JSONException {
+        HashSet<Pattern> result = new HashSet<>(array.length());
+        for (int i = 0; i < array.length(); i++) {
+            JSONObject element = array.getJSONObject(i);
+            String pattern = getString(element, "pattern");
+            int flags = 0;
+            if (element.optBoolean("isDotAll")) {
+                flags |= Pattern.DOTALL;
+            }
+            if (!element.optBoolean("isCaseSensitive")) {
+                flags |= Pattern.CASE_INSENSITIVE;
+            }
+            if (element.optBoolean("isMultiLine")) {
+                flags |= Pattern.MULTILINE;
+            }
+
+            if (pattern != null) {
+                result.add(Pattern.compile(pattern, flags));
+            }
         }
         return result;
     }

--- a/packages/bugsnag_flutter/ios/Classes/BugsnagFlutterPlugin.m
+++ b/packages/bugsnag_flutter/ios/Classes/BugsnagFlutterPlugin.m
@@ -51,6 +51,20 @@ static NSString *NSStringOrNil(id value) {
     return [value isKindOfClass:[NSString class]] ? value : nil;
 }
 
+static NSArray *stringsToRegularExpressions(NSArray *source) {
+    NSMutableArray *result = [NSMutableArray new];
+    for (NSString *pattern in source) {
+        NSError *error = nil;
+        NSRegularExpression *expression =  [NSRegularExpression regularExpressionWithPattern:pattern options:0 error:&error];
+        if (expression != nil) {
+            [result addObject: expression];
+        } else if (error) {
+            NSLog(@"Error encountered while parsing regular expression %@", error);
+        }
+    }
+    return result;
+}
+
 @interface BugsnagEvent (BugsnagFlutterPlugin)
 
 @property (nullable, nonatomic) NSArray *projectPackages;
@@ -278,12 +292,12 @@ static NSString *NSStringOrNil(id value) {
 
     NSArray *redactedKeys = arguments[@"redactedKeys"];
     if ([redactedKeys isKindOfClass:[NSArray class]]) {
-        configuration.redactedKeys = [NSSet setWithArray:redactedKeys];
+        configuration.redactedKeys = [NSSet setWithArray: stringsToRegularExpressions(redactedKeys)];
     }
 
     NSArray *discardClasses = arguments[@"discardClasses"];
     if ([discardClasses isKindOfClass:[NSArray class]]) {
-        configuration.discardClasses = [NSSet setWithArray:discardClasses];
+        configuration.discardClasses = [NSSet setWithArray: stringsToRegularExpressions(discardClasses)];
     }
 
     NSArray *enabledReleaseStages = arguments[@"enabledReleaseStages"];

--- a/packages/bugsnag_flutter/ios/Classes/BugsnagFlutterPlugin.m
+++ b/packages/bugsnag_flutter/ios/Classes/BugsnagFlutterPlugin.m
@@ -51,11 +51,22 @@ static NSString *NSStringOrNil(id value) {
     return [value isKindOfClass:[NSString class]] ? value : nil;
 }
 
-static NSArray *stringsToRegularExpressions(NSArray *source) {
+static NSArray *jsonToRegularExpressions(NSArray *source) {
     NSMutableArray *result = [NSMutableArray new];
-    for (NSString *pattern in source) {
+    for (NSDictionary *element in source) {
+        NSString *pattern = element[@"pattern"];
+        NSInteger options = 0;
+        if ([element[@"isDotAll"] boolValue]) {
+            options |= NSRegularExpressionDotMatchesLineSeparators;
+        }
+        if (![element[@"isCaseSensitive"] boolValue]) {
+            options |= NSRegularExpressionCaseInsensitive;
+        }
+        if ([element[@"isMultiLine"] boolValue]) {
+            options |= NSRegularExpressionAnchorsMatchLines;
+        }
         NSError *error = nil;
-        NSRegularExpression *expression =  [NSRegularExpression regularExpressionWithPattern:pattern options:0 error:&error];
+        NSRegularExpression *expression =  [NSRegularExpression regularExpressionWithPattern:pattern options:options error:&error];
         if (expression != nil) {
             [result addObject: expression];
         } else if (error) {
@@ -292,12 +303,12 @@ static NSArray *stringsToRegularExpressions(NSArray *source) {
 
     NSArray *redactedKeys = arguments[@"redactedKeys"];
     if ([redactedKeys isKindOfClass:[NSArray class]]) {
-        configuration.redactedKeys = [NSSet setWithArray: stringsToRegularExpressions(redactedKeys)];
+        configuration.redactedKeys = [NSSet setWithArray: jsonToRegularExpressions(redactedKeys)];
     }
 
     NSArray *discardClasses = arguments[@"discardClasses"];
     if ([discardClasses isKindOfClass:[NSArray class]]) {
-        configuration.discardClasses = [NSSet setWithArray: stringsToRegularExpressions(discardClasses)];
+        configuration.discardClasses = [NSSet setWithArray: jsonToRegularExpressions(discardClasses)];
     }
 
     NSArray *enabledReleaseStages = arguments[@"enabledReleaseStages"];

--- a/packages/bugsnag_flutter/lib/src/client.dart
+++ b/packages/bugsnag_flutter/lib/src/client.dart
@@ -13,6 +13,7 @@ import 'config.dart';
 import 'enum_utils.dart';
 import 'last_run_info.dart';
 import 'model.dart';
+import 'regexp_json.dart';
 
 final _notifier = {
   'name': 'Flutter Bugsnag Notifier',
@@ -787,9 +788,10 @@ class Bugsnag extends BugsnagClient with DelegateClient {
       'launchDurationMillis': launchDurationMillis,
       'sendLaunchCrashesSynchronously': sendLaunchCrashesSynchronously,
       'appHangThresholdMillis': appHangThresholdMillis,
-      'redactedKeys': List<String>.from(
-          redactedKeys?.map((e) => e.pattern) ?? {'password'}),
-      'discardClasses': List<String>.from(discardClasses.map((e) => e.pattern)),
+      'redactedKeys': List<dynamic>.from(redactedKeys?.map((e) => e.toJson()) ??
+          {RegExp('password').toJson()}),
+      'discardClasses':
+          List<dynamic>.from(discardClasses.map((e) => e.toJson())),
       if (enabledReleaseStages != null)
         'enabledReleaseStages': enabledReleaseStages.toList(),
       'enabledBreadcrumbTypes':

--- a/packages/bugsnag_flutter/lib/src/client.dart
+++ b/packages/bugsnag_flutter/lib/src/client.dart
@@ -21,7 +21,6 @@ final _notifier = {
 };
 
 abstract class BugsnagClient {
-
   final Map<String, Stopwatch> _openNetworkRequests = {};
 
   /// An utility error handling function that will send reported errors to
@@ -256,45 +255,47 @@ abstract class BugsnagClient {
   }
 
   void _onRequestStarted(String requestId) {
-      final stopwatch = Stopwatch()..start();
-      _openNetworkRequests[requestId] = stopwatch;
+    final stopwatch = Stopwatch()..start();
+    _openNetworkRequests[requestId] = stopwatch;
   }
 
   void _onRequestComplete(String requestId, dynamic data) {
-      final stopwatch = _openNetworkRequests.remove(requestId);
-      if (stopwatch != null && data is Map<String, dynamic>) {
-        final duration = stopwatch.elapsedMilliseconds;
-        final String? clientName = data["client"];
-        if (clientName == null) return;
+    final stopwatch = _openNetworkRequests.remove(requestId);
+    if (stopwatch != null && data is Map<String, dynamic>) {
+      final duration = stopwatch.elapsedMilliseconds;
+      final String? clientName = data["client"];
+      if (clientName == null) return;
 
-        String params = "";
-        final url = data["url"];
-        final splitUrl = url.split("?");
-        if (splitUrl != null && splitUrl.length > 1) {
-          params = splitUrl.last;
-        }
-        final int? statusCode = data["status_code"];
-        if (statusCode == null) return;
+      String params = "";
+      final url = data["url"];
+      final splitUrl = url.split("?");
+      if (splitUrl != null && splitUrl.length > 1) {
+        params = splitUrl.last;
+      }
+      final int? statusCode = data["status_code"];
+      if (statusCode == null) return;
 
-        final String status = statusCode < 400 ? "succeeded" : "failed";
-        // Assuming leaveBreadcrumb is a predefined method to log the event
-        leaveBreadcrumb("$clientName request $status", metadata: {
+      final String status = statusCode < 400 ? "succeeded" : "failed";
+      // Assuming leaveBreadcrumb is a predefined method to log the event
+      leaveBreadcrumb(
+        "$clientName request $status",
+        metadata: {
           "duration": duration,
           "method": data["http_method"],
           "url": splitUrl.first,
-          if(params.isNotEmpty)
-              "urlParams": params,
-          if(data["request_content_length"] != null && data["request_content_length"] > 0)
-              "requestContentLength": data["request_content_length"],
-          if(data["response_content_length"] != null && data["response_content_length"] > 0)
-              "responseContentLength": data["response_content_length"],
+          if (params.isNotEmpty) "urlParams": params,
+          if (data["request_content_length"] != null &&
+              data["request_content_length"] > 0)
+            "requestContentLength": data["request_content_length"],
+          if (data["response_content_length"] != null &&
+              data["response_content_length"] > 0)
+            "responseContentLength": data["response_content_length"],
           "status": statusCode,
-          },
-          type: BugsnagBreadcrumbType.request,
-        );
-      }
+        },
+        type: BugsnagBreadcrumbType.request,
+      );
+    }
   }
-
 }
 
 mixin DelegateClient implements BugsnagClient {
@@ -742,8 +743,8 @@ class Bugsnag extends BugsnagClient with DelegateClient {
     int launchDurationMillis = 5000,
     bool sendLaunchCrashesSynchronously = true,
     int appHangThresholdMillis = appHangThresholdFatalOnly,
-    Set<String> redactedKeys = const {'password'},
-    Set<String> discardClasses = const {},
+    Set<RegExp>? redactedKeys,
+    Set<RegExp> discardClasses = const {},
     Set<String>? enabledReleaseStages,
     Set<BugsnagEnabledBreadcrumbType>? enabledBreadcrumbTypes,
     BugsnagProjectPackages projectPackages =
@@ -786,8 +787,9 @@ class Bugsnag extends BugsnagClient with DelegateClient {
       'launchDurationMillis': launchDurationMillis,
       'sendLaunchCrashesSynchronously': sendLaunchCrashesSynchronously,
       'appHangThresholdMillis': appHangThresholdMillis,
-      'redactedKeys': List<String>.from(redactedKeys),
-      'discardClasses': List<String>.from(discardClasses),
+      'redactedKeys': List<String>.from(
+          redactedKeys?.map((e) => e.pattern) ?? {'password'}),
+      'discardClasses': List<String>.from(discardClasses.map((e) => e.pattern)),
       if (enabledReleaseStages != null)
         'enabledReleaseStages': enabledReleaseStages.toList(),
       'enabledBreadcrumbTypes':
@@ -833,7 +835,6 @@ class Bugsnag extends BugsnagClient with DelegateClient {
 
     return const <String>{};
   }
-
 }
 
 /// In order to determine where a crash happens Bugsnag needs to know which

--- a/packages/bugsnag_flutter/lib/src/regexp_json.dart
+++ b/packages/bugsnag_flutter/lib/src/regexp_json.dart
@@ -1,0 +1,8 @@
+extension RegExpJSON on RegExp {
+  dynamic toJson() => <String, dynamic>{
+        'pattern': pattern,
+        'isDotAll': isDotAll,
+        'isCaseSensitive': isCaseSensitive,
+        'isMultiLine': isMultiLine,
+      };
+}


### PR DESCRIPTION
## Goal

Bump bugsnag-android to the latest version.

## Design

The new version of bugsnag-android accepts redactedKeys and discardClasses only as regular expressions. In order to maintain consistency across platforms, the types in bugsnag-flutter were changed to RegExp and they are compiled to regular expressions on both native platforms.

## Changeset

Changed redactedKeys and discardClasses types to RegExp.

## Testing

Existing E2E tests