### PR TITLE
Temporarily restrict flutter fixture build to working macOS box

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -38,6 +38,8 @@ steps:
   - label: Build iOS Test Fixture 3.10.0
     key: "ios-fixture-3-10-0"
     timeout_in_minutes: 20
+    agents:
+      queue: ms-arm-12-4
     env:
       FLUTTER_BIN: "/opt/flutter/3.10.0/bin/flutter"
     commands:


### PR DESCRIPTION
## Goal

There appears to be a build error with the iOS test fixture on some of our build machines.  This restricts them to a known working machine, which will be lifted once we've investigated the failure reasons.