### PR TITLE
Added trace ID to error events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## TBD
+
+- Getting the correlation trace ID and span ID through `flutter_bridge` and adding it to events.
+  [251](https://github.com/bugsnag/bugsnag-flutter/pull/251)
+
 ## 3.1.1 (2024-04-24)
 
 - Fixed: Navigator.pushAndRemoveUntil throws exception [#242](https://github.com/bugsnag/bugsnag-flutter/pull/242)

--- a/features/fixtures/app/pubspec.lock
+++ b/features/fixtures/app/pubspec.lock
@@ -17,6 +17,15 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
+  bugsnag_bridge:
+    dependency: transitive
+    description:
+      path: "packages/bugsnag-flutter-bridge"
+      ref: HEAD
+      resolved-ref: "0a2b35f8b0a5908082ce0f57e85fa9c027a0f0ad"
+      url: "https://github.com/bugsnag/bugsnag-flutter-common"
+    source: git
+    version: "0.1.0"
   bugsnag_flutter:
     dependency: "direct main"
     description:
@@ -58,10 +67,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
+      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.1"
+    version: "1.17.2"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -140,18 +149,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
+      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.15"
+    version: "0.12.16"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.5.0"
   meta:
     dependency: transitive
     description:
@@ -241,10 +250,10 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
   stack_trace:
     dependency: transitive
     description:
@@ -281,10 +290,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
+      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "0.6.0"
   typed_data:
     dependency: transitive
     description:
@@ -301,6 +310,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.4-beta"
   win32:
     dependency: transitive
     description:
@@ -318,5 +335,5 @@ packages:
     source: hosted
     version: "1.0.4"
 sdks:
-  dart: ">=3.0.0 <4.0.0"
+  dart: ">=3.1.0-185.0.dev <4.0.0"
   flutter: ">=3.10.0"

--- a/packages/bugsnag_flutter/android/src/main/java/com/bugsnag/flutter/BugsnagFlutter.java
+++ b/packages/bugsnag_flutter/android/src/main/java/com/bugsnag/flutter/BugsnagFlutter.java
@@ -33,6 +33,7 @@ import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
+import java.util.UUID;
 
 class BugsnagFlutter {
 
@@ -42,6 +43,8 @@ class BugsnagFlutter {
 
     private static boolean isAnyStarted = false;
     private boolean isStarted = false;
+
+    static final int HEX_LONG_LENGTH = 16;
 
     /*
      ***********************************************************************************************
@@ -406,6 +409,23 @@ class BugsnagFlutter {
             event.addMetadata("flutter", (Map<String, Object>) flutterMetadata);
         }
 
+        JSONObject correlation = args.optJSONObject("correlation");
+        if (correlation != null) {
+
+            String traceId = getString(correlation, "traceId");
+            String spanId = getString(correlation, "spanId");
+            if (traceId != null &&
+                    traceId.length() == HEX_LONG_LENGTH * 2 &&
+                    spanId != null &&
+                    spanId.length() == HEX_LONG_LENGTH
+            ) {
+                long traceIdMostSignificantBits = hexToLong(traceId.substring(0, HEX_LONG_LENGTH));
+                long traceIdLeastSignificantBits = hexToLong(traceId.substring(HEX_LONG_LENGTH));
+                long spanIdAsLong = hexToLong(spanId);
+                event.setTraceCorrelation(new UUID(traceIdMostSignificantBits, traceIdLeastSignificantBits), spanIdAsLong);
+            }
+        }
+
         if (deliver) {
             // Flutter layer has asked us to deliver the Event immediately
             client.deliverEvent(event);
@@ -441,5 +461,10 @@ class BugsnagFlutter {
 
     boolean hasString(JSONObject args, String key) {
         return getString(args, key) != null;
+    }
+
+    static long hexToLong(String hex) {
+        return Long.parseLong(hex.substring(0, 2), 16) << 56 |
+                Long.parseLong(hex.substring(2), 16);
     }
 }

--- a/packages/bugsnag_flutter/android/src/main/java/com/bugsnag/flutter/BugsnagFlutter.java
+++ b/packages/bugsnag_flutter/android/src/main/java/com/bugsnag/flutter/BugsnagFlutter.java
@@ -411,18 +411,21 @@ class BugsnagFlutter {
 
         JSONObject correlation = args.optJSONObject("correlation");
         if (correlation != null) {
-
-            String traceId = getString(correlation, "traceId");
-            String spanId = getString(correlation, "spanId");
-            if (traceId != null &&
-                    traceId.length() == HEX_LONG_LENGTH * 2 &&
-                    spanId != null &&
-                    spanId.length() == HEX_LONG_LENGTH
-            ) {
-                long traceIdMostSignificantBits = hexToLong(traceId.substring(0, HEX_LONG_LENGTH));
-                long traceIdLeastSignificantBits = hexToLong(traceId.substring(HEX_LONG_LENGTH));
-                long spanIdAsLong = hexToLong(spanId);
-                event.setTraceCorrelation(new UUID(traceIdMostSignificantBits, traceIdLeastSignificantBits), spanIdAsLong);
+            try {
+                String traceId = getString(correlation, "traceId");
+                String spanId = getString(correlation, "spanId");
+                if (traceId != null &&
+                        traceId.length() == HEX_LONG_LENGTH * 2 &&
+                        spanId != null &&
+                        spanId.length() == HEX_LONG_LENGTH
+                ) {
+                    long traceIdMostSignificantBits = hexToLong(traceId.substring(0, HEX_LONG_LENGTH));
+                    long traceIdLeastSignificantBits = hexToLong(traceId.substring(HEX_LONG_LENGTH));
+                    long spanIdAsLong = hexToLong(spanId);
+                    event.setTraceCorrelation(new UUID(traceIdMostSignificantBits, traceIdLeastSignificantBits), spanIdAsLong);
+                }
+            } catch(Exception e) {
+                Log.e("BugsnagFlutter", "correlation parsing", e);
             }
         }
 
@@ -463,7 +466,7 @@ class BugsnagFlutter {
         return getString(args, key) != null;
     }
 
-    static long hexToLong(String hex) {
+    private static long hexToLong(String hex) {
         return Long.parseLong(hex.substring(0, 2), 16) << 56 |
                 Long.parseLong(hex.substring(2), 16);
     }

--- a/packages/bugsnag_flutter/android/src/main/java/com/bugsnag/flutter/BugsnagFlutter.java
+++ b/packages/bugsnag_flutter/android/src/main/java/com/bugsnag/flutter/BugsnagFlutter.java
@@ -425,7 +425,7 @@ class BugsnagFlutter {
                     event.setTraceCorrelation(new UUID(traceIdMostSignificantBits, traceIdLeastSignificantBits), spanIdAsLong);
                 }
             } catch(Exception e) {
-                Log.e("BugsnagFlutter", "correlation parsing", e);
+                // ignore the error, the error correlation will be missing
             }
         }
 

--- a/packages/bugsnag_flutter/ios/Classes/BugsnagFlutterPlugin.m
+++ b/packages/bugsnag_flutter/ios/Classes/BugsnagFlutterPlugin.m
@@ -475,6 +475,15 @@ static NSArray *jsonToRegularExpressions(NSArray *source) {
             [event addMetadata:DartCodeBuildId withKey:@"buildID" toSection:@"flutter"];
         }
     }
+
+    NSDictionary *correlation = json[@"correlation"];
+    if (correlation != nil) {
+        NSString *traceId = correlation[@"traceId"];
+        NSString *spanId = correlation[@"spanId"];
+        if (traceId != nil && spanId != nil) {
+            event.correlation = [[BugsnagCorrelation alloc] initWithTraceId:traceId spanId:spanId];            
+        }
+    }
     
     if ([json[@"deliver"] boolValue]) {
         [client notifyInternal:event block:nil];

--- a/packages/bugsnag_flutter/ios/Classes/BugsnagFlutterPlugin.m
+++ b/packages/bugsnag_flutter/ios/Classes/BugsnagFlutterPlugin.m
@@ -481,7 +481,7 @@ static NSArray *jsonToRegularExpressions(NSArray *source) {
         NSString *traceId = correlation[@"traceId"];
         NSString *spanId = correlation[@"spanId"];
         if (traceId != nil && spanId != nil) {
-            event.correlation = [[BugsnagCorrelation alloc] initWithTraceId:traceId spanId:spanId];            
+            [event setCorrelationTraceId:traceId spanId:spanId];
         }
     }
     

--- a/packages/bugsnag_flutter/ios/bugsnag_flutter.podspec
+++ b/packages/bugsnag_flutter/ios/bugsnag_flutter.podspec
@@ -16,5 +16,5 @@ Bugsnag crash monitoring and reporting tool for Flutter apps
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
 
   s.dependency 'Flutter'
-  s.dependency 'Bugsnag', '6.28.0'
+  s.dependency 'Bugsnag', '6.29.0'
 end

--- a/packages/bugsnag_flutter/ios/bugsnag_flutter.podspec
+++ b/packages/bugsnag_flutter/ios/bugsnag_flutter.podspec
@@ -16,5 +16,5 @@ Bugsnag crash monitoring and reporting tool for Flutter apps
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
 
   s.dependency 'Flutter'
-  s.dependency 'Bugsnag', '6.29.0'
+  s.dependency 'Bugsnag', '6.30.0'
 end

--- a/packages/bugsnag_flutter/lib/src/client.dart
+++ b/packages/bugsnag_flutter/lib/src/client.dart
@@ -619,11 +619,11 @@ class ChannelClient extends BugsnagClient {
           PlatformDispatcher.instance.initialLifecycleState,
       if (lifecycleState != null) 'lifecycleState': lifecycleState,
     };
-    final spanContext = contextProvider.getCurrentSpanContext();
-    final correlation = spanContext != null
+    final traceContext = contextProvider.getCurrentTraceContext();
+    final correlation = traceContext != null
         ? {
-            'spanId': spanContext.spanId,
-            'traceId': spanContext.traceId,
+            'spanId': traceContext.spanId,
+            'traceId': traceContext.traceId,
           }
         : null;
     final eventJson = await _channel.invokeMethod(

--- a/packages/bugsnag_flutter/pubspec.yaml
+++ b/packages/bugsnag_flutter/pubspec.yaml
@@ -13,6 +13,11 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  bugsnag_bridge:
+    git: #TODO: Remove once bugsnag_bridge is released to pub.dev
+      url: https://github.com/bugsnag/bugsnag-flutter-common
+      ref: robert/bugsnag-bridge-span-context
+      path: packages/bugsnag-flutter-bridge
 
 dev_dependencies:
   flutter_test:

--- a/packages/bugsnag_flutter/pubspec.yaml
+++ b/packages/bugsnag_flutter/pubspec.yaml
@@ -5,6 +5,7 @@ homepage: https://www.bugsnag.com/
 documentation: https://docs.bugsnag.com/platforms/flutter/
 repository: https://github.com/bugsnag/bugsnag-flutter
 issue_tracker: https://github.com/bugsnag/bugsnag-flutter/issues
+publish_to: none
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
@@ -16,7 +17,6 @@ dependencies:
   bugsnag_bridge:
     git: #TODO: Remove once bugsnag_bridge is released to pub.dev
       url: https://github.com/bugsnag/bugsnag-flutter-common
-      ref: robert/bugsnag-bridge-span-context
       path: packages/bugsnag-flutter-bridge
 
 dev_dependencies:

--- a/packages/bugsnag_flutter/pubspec.yaml
+++ b/packages/bugsnag_flutter/pubspec.yaml
@@ -5,7 +5,6 @@ homepage: https://www.bugsnag.com/
 documentation: https://docs.bugsnag.com/platforms/flutter/
 repository: https://github.com/bugsnag/bugsnag-flutter
 issue_tracker: https://github.com/bugsnag/bugsnag-flutter/issues
-publish_to: none
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
@@ -14,10 +13,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  bugsnag_bridge:
-    git: #TODO: Remove once bugsnag_bridge is released to pub.dev
-      url: https://github.com/bugsnag/bugsnag-flutter-common
-      path: packages/bugsnag-flutter-bridge
+  bugsnag_bridge: ^2.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Goal

Include the ID of the current trace and span ID in errors when both bugsnag-flutter and bugsnag-flutter-performance are included in an application

## Design

BugsnagContextProvider is used to receive traceId and spanId from Flutter Performance and then the values are included in bugsnag-cocoa and bugsnag-android events

## Testing

Existing E2E tests