### PR TITLE
Upgrade compileSdkVersion from 29 to 34.

### DIFF
--- a/packages/bugsnag_flutter/android/build.gradle
+++ b/packages/bugsnag_flutter/android/build.gradle
@@ -23,7 +23,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 34
 
     if (android.hasProperty('namespace')) {
         namespace 'com.bugsnag.flutter'


### PR DESCRIPTION
## Goal

<!-- Why is this change necessary? -->

The library is giving errors after the last update of flutter "3.24.0". This is the error "build/bugsnag_flutter/intermediates/merged_res/release/values/values.xml:194: AAPT: error: resource android:attr/lStar not found". This is the fix for the error.

## Design

<!-- Why was this approach used? -->

## Changeset

<!-- What changed? -->

## Testing

<!-- How was it tested? What manual and automated tests were
     run/added? -->
     Just run it again with the new changes and it started working, it is a known issue with the new version of flutter.