### PR TITLE
Upgrade compileSdkVersion to 34 to fix "lStar not found" build issue

### DIFF
--- a/packages/bugsnag_flutter/android/build.gradle
+++ b/packages/bugsnag_flutter/android/build.gradle
@@ -23,7 +23,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 34
 
     if (android.hasProperty('namespace')) {
         namespace 'com.bugsnag.flutter'


### PR DESCRIPTION
## Goal

This change is necessary to resolve an issue during the build process caused by an outdated `compileSdkVersion`. Specifically, the error occurred while verifying Android resources:
```bash
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ‘:bugsnag_flutter:verifyReleaseResources’.
> A failure occurred while executing com.android.build.gradle.tasks.VerifyLibraryResourcesTask$Action
   > Android resource linking failed
     ERROR: /Users/gdelataillade/dev/evolum_app/build/bugsnag_flutter/intermediates/merged_res/release/mergeReleaseResources/values/values.xml:194: AAPT: error: resource android:attr/lStar not found.
```

## Design

The approach used was to upgrade the `compileSdkVersion` from 31 to 34 in the Bugsnag Flutter dependency. This fixes the missing resource issue, as the newer SDK version supports the required attributes.

## Changeset

Updated `compileSdkVersion` from 31 to 34 in the `bugsnag_flutter` module to align with the latest Android SDK compatibility.

## Testing

The change was tested by rebuilding the Flutter project using the new SDK version. I use the following environment:

	Flutter (Channel stable, 3.24.3, on macOS 15.0.1 24A348 darwin-arm64)

After the update, the build was successful, and no further errors related to resource linking were encountered.