### PR TITLE
Bumped bugsnag-android dependency version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## TBD
+
+- Update bugsnag-android from v6.6.0 to [v6.10.0](https://github.com/bugsnag/bugsnag-android/blob/master/CHANGELOG.md#6100-2024-11-14)
+
 ## 4.1.0 (2024-11-04)
 
 - Upgrade Android compileSdkVersion from 29 to 31.

--- a/packages/bugsnag_flutter/android/build.gradle
+++ b/packages/bugsnag_flutter/android/build.gradle
@@ -50,7 +50,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.bugsnag:bugsnag-android:6.6.0'
+    implementation 'com.bugsnag:bugsnag-android:6.10.0'
     testImplementation 'junit:junit:4.12'
 }
 


### PR DESCRIPTION
## Goal

There is an error when the library is used with Android SDK 34 and above. We need to bump the version of bugsnag-android used by bugsnag-flutter to work with Android SDK version 34