### PR TITLE
Always upload maze_output.zip as build artifact

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -63,7 +63,9 @@ steps:
     plugins:
       artifacts#v1.5.0:
         download: "features/fixtures/app/build/ios/ipa/app-3.10.0.ipa"
-        upload: "maze_output/failed/**/*"
+        upload:
+          - "maze_output/maze_output.zip"
+          - "maze_output/failed/**/*"
       docker-compose#v4.7.0:
         pull: maze-runner
         run: maze-runner
@@ -108,7 +110,9 @@ steps:
     plugins:
       artifacts#v1.5.0:
         download: "features/fixtures/app/build/app/outputs/flutter-apk/app-release-3.10.0.apk"
-        upload: "maze_output/failed/**/*"
+        upload:
+          - "maze_output/maze_output.zip"
+          - "maze_output/failed/**/*"
       docker-compose#v4.7.0:
         pull: maze-runner
         run: maze-runner


### PR DESCRIPTION
## Goal

Always upload maze_output.zip as build artifact to assist with debugging of test failures - it gives us an easy reference point for what requests should look like.

## Testing

Covered by CI.