### PR TITLE
Use macOS 15 build servers in CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,5 @@
 agents:
-  queue: macos-14
+  queue: macos-15
 
 env:
   JAVA_VERSION: "17"
@@ -41,8 +41,6 @@ steps:
   - label: Build iOS Test Fixture 3.10.0
     key: "ios-fixture-3-10-0"
     timeout_in_minutes: 20
-    agents:
-      queue: macos-12-arm
     env:
       FLUTTER_VERSION: "3.10.0"
     commands:


### PR DESCRIPTION
## Goal

Use macOS 15 build servers in CI.

## Testing

Covered by CI.