### PR TITLE
fix formatting for 2.x to 3.x in UPGRADING.MD

### DIFF
--- a/UPGRADING.MD
+++ b/UPGRADING.MD
@@ -23,6 +23,7 @@ bugsnag.start(
   },
   // ...
 );
+```
 
 ## 2.x to 3.x
 
@@ -50,7 +51,7 @@ Future<void> main() async {
   // configuration here
   );
   runApp(MyApplication());
-}
+}  
 ```
 
 Telemetry options have been simplified into a new dedicated type instead of being a set. To specify custom telemetry options, use:


### PR DESCRIPTION
fix formatting for 2.x to 3.x in UPGRADING.MD

## Goal  
Create nicely formatted documentation.

<!-- Why is this change necessary? -->
It will help users to be able to read with clarity how to upgrade from 2.x to 3.x

## Design
This was just a fix

<!-- Why was this approach used? -->

## Changeset

<!-- What changed? -->
The UPGRADE.md

## Testing
The md was was rendered with a md code editor.

<!-- How was it tested? What manual and automated tests were
     run/added? -->
I just checked that the md file was properly formatted.