### PR TITLE
Use w3c touch action

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -147,8 +147,8 @@ steps:
             command:
               - "--app=/app/features/fixtures/app/build/app/outputs/flutter-apk/app-release-{{matrix}}.apk"
               - "--farm=bs"
-              - "--device=ANDROID_12"
-              - "--appium-version=1.22.0"
+              - "--device=ANDROID_15"
+              - "--appium-version=2.19.0"
               - "--fail-fast"
           test-collector#v1.10.2:
             files: "reports/TEST-*.xml"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -108,7 +108,7 @@ steps:
             command:
               - "--app=/app/features/fixtures/app/build/ios/ipa/app-{{matrix}}.ipa"
               - "--farm=bb"
-              - "--device=IOS_14|IOS_15|IOS_16"
+              - "--device=IOS_17|IOS_18|IOS_26"
               - "--no-tunnel"
               - "--aws-public-ip"
               - "--fail-fast"

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,7 @@
 Package.resolved
 Podfile.lock
 maze_output/
+maze-runner.log
 Gemfile.lock
 .idea/
+bugsnag-flutter.iml

--- a/features/steps/flutter_steps.rb
+++ b/features/steps/flutter_steps.rb
@@ -32,13 +32,13 @@ def execute_command(action, scenario_name)
 end
 
 When('I relaunch the app') do
-  Maze::Api::Appium::AppManager.new.launch
+  Maze::Api::Appium::AppManager.new.activate
 end
 
 When("I relaunch the app after a crash") do
   # Wait for the app to stop running before relaunching
   step 'the app is not running'
-  Maze::Api::Appium::AppManager.new.launch
+  Maze::Api::Appium::AppManager.new.activate
 end
 
 Then('the app is not running') do

--- a/features/steps/flutter_steps.rb
+++ b/features/steps/flutter_steps.rb
@@ -22,9 +22,7 @@ def execute_command(action, scenario_name)
   command = { action: action, scenario_name: scenario_name, extra_config: extra_config }
   Maze::Server.commands.add command
   
-  touch_action = Appium::TouchAction.new
-  touch_action.tap({:x => 200, :y => 200})
-  touch_action.perform
+  Maze::Api::Appium::UiManager.new.touch_at(200, 200)
 
   $extra_config = ''
   # Ensure fixture has read the command


### PR DESCRIPTION
## Goal

Unblocks the use of Appium 2.5.0 (automatically used on BitBar by iOS 17 and later), which removes the ability to use the `TouchAction`.  

## Design

The touch is now performed using Maze Runner's new W3C action approach, allowing us to use newer Appium and iOS versions.  I've also updated the Android side as the new approach is _not_ supported in Appium 1.  To some extent this is a trial with the latest Appium 2 release - we had previously avoided it due to various issues.

## Testing

Covered by CI.