### PR TITLE
add isStarted property to BugsnagClient

### DIFF
--- a/features/call_bugsnag_before_start.feature
+++ b/features/call_bugsnag_before_start.feature
@@ -1,6 +1,6 @@
-Feature: Calling Bugsnag methods before start() fails without isStarted
+Feature: Developers can verify Bugsnag initialization using isStarted
 
-  Scenario: Methods throw exception when called before start()
+  Scenario: Methods work correctly after initialization with isStarted verification
     Given I run "CallBugsnagBeforeStartScenario"
     Then I should receive no error
 

--- a/features/call_bugsnag_before_start.feature
+++ b/features/call_bugsnag_before_start.feature
@@ -2,5 +2,5 @@ Feature: Calling Bugsnag methods before start() fails without isStarted
 
   Scenario: Methods throw exception when called before start()
     Given I run "CallBugsnagBeforeStartScenario"
-    Then I should not receive an error
+    Then I should receive no error
 

--- a/features/call_bugsnag_before_start.feature
+++ b/features/call_bugsnag_before_start.feature
@@ -1,0 +1,6 @@
+Feature: Calling Bugsnag methods before start() fails without isStarted
+
+  Scenario: Methods throw exception when called before start()
+    Given I run "CallBugsnagBeforeStartScenario"
+    Then I should not receive an error
+

--- a/features/fixtures/app/lib/scenarios/call_bugsnag_before_start_scenario.dart
+++ b/features/fixtures/app/lib/scenarios/call_bugsnag_before_start_scenario.dart
@@ -44,11 +44,6 @@ class CallBugsnagBeforeStartScenario extends Scenario {
     // Call addMetadata - should succeed
     await bugsnag.addMetadata('custom', {'key': 'value'});
 
-    // Call notify - should succeed
-    await bugsnag.notify(
-      Exception('Test exception'),
-      StackTrace.current,
-    );
 
     // Verify we can also use isStarted to guard calls defensively
     if (bugsnag.isStarted) {

--- a/features/fixtures/app/lib/scenarios/call_bugsnag_before_start_scenario.dart
+++ b/features/fixtures/app/lib/scenarios/call_bugsnag_before_start_scenario.dart
@@ -1,0 +1,120 @@
+import 'package:bugsnag_flutter/bugsnag_flutter.dart';
+
+import 'scenario.dart';
+
+class CallBugsnagBeforeStartScenario extends Scenario {
+  @override
+  Future<void> run() async {
+    // This scenario demonstrates the problem: calling Bugsnag methods before start()
+    // Currently, this will throw an exception:
+    // "You must start or attach bugsnag before calling any other methods"
+    
+    // Without isStarted, developers either have to:
+    // 1. Wrap calls in try/catch
+    // 2. Keep track of initialization state themselves
+    // 3. Hope they call methods in the right order
+    
+    try {
+      // Try to call setContext before starting - this should fail
+      await bugsnag.setContext('test-context');
+      
+      throw AssertionError(
+        'Expected an exception when calling setContext before start(), '
+        'but the call succeeded. This indicates bugsnag was already initialized.'
+      );
+    } catch (e) {
+      // Expected to fail with: "You must start or attach bugsnag before calling any other methods"
+      if (e is AssertionError) {
+        rethrow;
+      }
+      
+      final errorMessage = e.toString();
+      if (!errorMessage.contains('start or attach')) {
+        throw AssertionError(
+          'Expected exception message to contain "start or attach" '
+          'but got: $errorMessage'
+        );
+      }
+      
+      print('[Test] ✓ Correctly threw exception when calling setContext before start()');
+    }
+
+    try {
+      // Try to call setUser before starting - this should also fail
+      await bugsnag.setUser(id: 'test-user-id', name: 'Test User');
+      
+      throw AssertionError(
+        'Expected an exception when calling setUser before start(), '
+        'but the call succeeded.'
+      );
+    } catch (e) {
+      if (e is AssertionError) {
+        rethrow;
+      }
+      
+      final errorMessage = e.toString();
+      if (!errorMessage.contains('start or attach')) {
+        throw AssertionError(
+          'Expected exception message to contain "start or attach" '
+          'but got: $errorMessage'
+        );
+      }
+      
+      print('[Test] ✓ Correctly threw exception when calling setUser before start()');
+    }
+
+    try {
+      // Try to call addMetadata before starting - this should also fail
+      await bugsnag.addMetadata('custom', {'key': 'value'});
+      
+      throw AssertionError(
+        'Expected an exception when calling addMetadata before start(), '
+        'but the call succeeded.'
+      );
+    } catch (e) {
+      if (e is AssertionError) {
+        rethrow;
+      }
+      
+      final errorMessage = e.toString();
+      if (!errorMessage.contains('start or attach')) {
+        throw AssertionError(
+          'Expected exception message to contain "start or attach" '
+          'but got: $errorMessage'
+        );
+      }
+      
+      print('[Test] ✓ Correctly threw exception when calling addMetadata before start()');
+    }
+
+    try {
+      // Try to call notify before starting - this should also fail
+      await bugsnag.notify(
+        Exception('Test exception'),
+        StackTrace.current,
+      );
+      
+      throw AssertionError(
+        'Expected an exception when calling notify before start(), '
+        'but the call succeeded.'
+      );
+    } catch (e) {
+      if (e is AssertionError) {
+        rethrow;
+      }
+      
+      final errorMessage = e.toString();
+      if (!errorMessage.contains('start or attach')) {
+        throw AssertionError(
+          'Expected exception message to contain "start or attach" '
+          'but got: $errorMessage'
+        );
+      }
+      
+      print('[Test] ✓ Correctly threw exception when calling notify before start()');
+    }
+
+    print('[Test] ✓ All failure cases verified - methods correctly throw exceptions before initialization');
+  }
+}
+

--- a/features/fixtures/app/lib/scenarios/call_bugsnag_before_start_scenario.dart
+++ b/features/fixtures/app/lib/scenarios/call_bugsnag_before_start_scenario.dart
@@ -5,116 +5,63 @@ import 'scenario.dart';
 class CallBugsnagBeforeStartScenario extends Scenario {
   @override
   Future<void> run() async {
-    // This scenario demonstrates the problem: calling Bugsnag methods before start()
-    // Currently, this will throw an exception:
-    // "You must start or attach bugsnag before calling any other methods"
-    
-    // Without isStarted, developers either have to:
-    // 1. Wrap calls in try/catch
-    // 2. Keep track of initialization state themselves
-    // 3. Hope they call methods in the right order
-    
-    try {
-      // Try to call setContext before starting - this should fail
-      await bugsnag.setContext('test-context');
-      
+    // This scenario demonstrates the isStarted property: developers can check
+    // initialization state before calling Bugsnag methods, avoiding exceptions
+    // and enabling graceful handling of pre-init calls.
+
+    // Verify isStarted is false before initialization
+    if (bugsnag.isStarted) {
       throw AssertionError(
-        'Expected an exception when calling setContext before start(), '
-        'but the call succeeded. This indicates bugsnag was already initialized.'
+        'Expected bugsnag.isStarted to be false before start(), '
+        'but it was true. This indicates bugsnag was already initialized.'
       );
-    } catch (e) {
-      // Expected to fail with: "You must start or attach bugsnag before calling any other methods"
-      if (e is AssertionError) {
-        rethrow;
-      }
-      
-      final errorMessage = e.toString();
-      if (!errorMessage.contains('start or attach')) {
-        throw AssertionError(
-          'Expected exception message to contain "start or attach" '
-          'but got: $errorMessage'
-        );
-      }
-      
-      print('[Test] ✓ Correctly threw exception when calling setContext before start()');
+    }
+    print('[Test] ✓ bugsnag.isStarted is false before initialization');
+
+    // Initialize Bugsnag
+    await bugsnag.start(autoTrackSessions: false);
+
+    // Verify isStarted is true after initialization
+    if (!bugsnag.isStarted) {
+      throw AssertionError(
+        'Expected bugsnag.isStarted to be true after start(), '
+        'but it was false.'
+      );
+    }
+    print('[Test] ✓ bugsnag.isStarted is true after start()');
+
+    // Now that we've verified initialization, methods should succeed
+    // without throwing exceptions
+
+    // Call setContext - should succeed
+    await bugsnag.setContext('test-context');
+    print('[Test] ✓ setContext() succeeded after initialization');
+
+    // Call setUser - should succeed
+    await bugsnag.setUser(id: 'test-user-id', name: 'Test User');
+    print('[Test] ✓ setUser() succeeded after initialization');
+
+    // Call addMetadata - should succeed
+    await bugsnag.addMetadata('custom', {'key': 'value'});
+    print('[Test] ✓ addMetadata() succeeded after initialization');
+
+    // Call notify - should succeed
+    await bugsnag.notify(
+      Exception('Test exception'),
+      StackTrace.current,
+    );
+    print('[Test] ✓ notify() succeeded after initialization');
+
+    // Verify we can also use isStarted to guard calls defensively
+    if (bugsnag.isStarted) {
+      await bugsnag.leaveBreadcrumb(
+        'Scenario completed',
+        metadata: {'status': 'success'},
+      );
+      print('[Test] ✓ Defensive isStarted check prevents exceptions');
     }
 
-    try {
-      // Try to call setUser before starting - this should also fail
-      await bugsnag.setUser(id: 'test-user-id', name: 'Test User');
-      
-      throw AssertionError(
-        'Expected an exception when calling setUser before start(), '
-        'but the call succeeded.'
-      );
-    } catch (e) {
-      if (e is AssertionError) {
-        rethrow;
-      }
-      
-      final errorMessage = e.toString();
-      if (!errorMessage.contains('start or attach')) {
-        throw AssertionError(
-          'Expected exception message to contain "start or attach" '
-          'but got: $errorMessage'
-        );
-      }
-      
-      print('[Test] ✓ Correctly threw exception when calling setUser before start()');
-    }
-
-    try {
-      // Try to call addMetadata before starting - this should also fail
-      await bugsnag.addMetadata('custom', {'key': 'value'});
-      
-      throw AssertionError(
-        'Expected an exception when calling addMetadata before start(), '
-        'but the call succeeded.'
-      );
-    } catch (e) {
-      if (e is AssertionError) {
-        rethrow;
-      }
-      
-      final errorMessage = e.toString();
-      if (!errorMessage.contains('start or attach')) {
-        throw AssertionError(
-          'Expected exception message to contain "start or attach" '
-          'but got: $errorMessage'
-        );
-      }
-      
-      print('[Test] ✓ Correctly threw exception when calling addMetadata before start()');
-    }
-
-    try {
-      // Try to call notify before starting - this should also fail
-      await bugsnag.notify(
-        Exception('Test exception'),
-        StackTrace.current,
-      );
-      
-      throw AssertionError(
-        'Expected an exception when calling notify before start(), '
-        'but the call succeeded.'
-      );
-    } catch (e) {
-      if (e is AssertionError) {
-        rethrow;
-      }
-      
-      final errorMessage = e.toString();
-      if (!errorMessage.contains('start or attach')) {
-        throw AssertionError(
-          'Expected exception message to contain "start or attach" '
-          'but got: $errorMessage'
-        );
-      }
-      
-      print('[Test] ✓ Correctly threw exception when calling notify before start()');
-    }
-
-    print('[Test] ✓ All failure cases verified - methods correctly throw exceptions before initialization');
+    print('[Test] ✓ All methods work correctly after initialization - isStarted property enables safe usage');
   }
 }
 

--- a/features/fixtures/app/lib/scenarios/call_bugsnag_before_start_scenario.dart
+++ b/features/fixtures/app/lib/scenarios/call_bugsnag_before_start_scenario.dart
@@ -16,10 +16,13 @@ class CallBugsnagBeforeStartScenario extends Scenario {
         'but it was true. This indicates bugsnag was already initialized.'
       );
     }
-    print('[Test] ✓ bugsnag.isStarted is false before initialization');
 
-    // Initialize Bugsnag
-    await bugsnag.start(autoTrackSessions: false);
+    // Initialize Bugsnag via MazeRunner endpoints to avoid sending to
+    // production endpoints during fixture runs.
+    await bugsnag.start(
+      endpoints: endpoints,
+      autoTrackSessions: false,
+    );
 
     // Verify isStarted is true after initialization
     if (!bugsnag.isStarted) {
@@ -28,29 +31,24 @@ class CallBugsnagBeforeStartScenario extends Scenario {
         'but it was false.'
       );
     }
-    print('[Test] ✓ bugsnag.isStarted is true after start()');
 
     // Now that we've verified initialization, methods should succeed
     // without throwing exceptions
 
     // Call setContext - should succeed
     await bugsnag.setContext('test-context');
-    print('[Test] ✓ setContext() succeeded after initialization');
 
     // Call setUser - should succeed
     await bugsnag.setUser(id: 'test-user-id', name: 'Test User');
-    print('[Test] ✓ setUser() succeeded after initialization');
 
     // Call addMetadata - should succeed
     await bugsnag.addMetadata('custom', {'key': 'value'});
-    print('[Test] ✓ addMetadata() succeeded after initialization');
 
     // Call notify - should succeed
     await bugsnag.notify(
       Exception('Test exception'),
       StackTrace.current,
     );
-    print('[Test] ✓ notify() succeeded after initialization');
 
     // Verify we can also use isStarted to guard calls defensively
     if (bugsnag.isStarted) {
@@ -58,10 +56,8 @@ class CallBugsnagBeforeStartScenario extends Scenario {
         'Scenario completed',
         metadata: {'status': 'success'},
       );
-      print('[Test] ✓ Defensive isStarted check prevents exceptions');
     }
 
-    print('[Test] ✓ All methods work correctly after initialization - isStarted property enables safe usage');
   }
 }
 

--- a/features/fixtures/app/lib/scenarios/scenarios.dart
+++ b/features/fixtures/app/lib/scenarios/scenarios.dart
@@ -4,6 +4,7 @@ import 'package:MazeRunner/scenarios/null_user_scenario.dart';
 import 'app_hang_scenario.dart';
 import 'attach_bugsnag_scenario.dart';
 import 'breadcrumbs_scenario.dart';
+import 'call_bugsnag_before_start_scenario.dart';
 import 'detect_enabled_errors.dart';
 import 'discard_classes_scenario.dart';
 import 'error_handler_scenario.dart';
@@ -39,6 +40,7 @@ final List<ScenarioInfo<Scenario>> scenarios = [
   ScenarioInfo('AppHangScenario', () => AppHangScenario()),
   ScenarioInfo('AttachBugsnagScenario', () => AttachBugsnagScenario()),
   ScenarioInfo('BreadcrumbsScenario', () => BreadcrumbsScenario()),
+  ScenarioInfo('CallBugsnagBeforeStartScenario', () => CallBugsnagBeforeStartScenario()),
   ScenarioInfo(
       'DetectEnabledErrorsScenario', () => DetectEnabledErrorsScenario()),
   ScenarioInfo('DiscardClassesScenario', () => DiscardClassesScenario()),

--- a/packages/bugsnag_flutter/android/src/main/java/com/bugsnag/flutter/BugsnagFlutter.java
+++ b/packages/bugsnag_flutter/android/src/main/java/com/bugsnag/flutter/BugsnagFlutter.java
@@ -265,6 +265,10 @@ class BugsnagFlutter {
         return Bugsnag.getGroupingDiscriminator(); // may be null
     }
 
+    Boolean isStarted(@Nullable JSONObject args) {
+        return isStarted;
+    }
+
     Void leaveBreadcrumb(@Nullable JSONObject args) throws Exception {
         if (args != null &&
                 hasString(args, "name") &&

--- a/packages/bugsnag_flutter/android/src/main/java/com/bugsnag/flutter/BugsnagFlutter.java
+++ b/packages/bugsnag_flutter/android/src/main/java/com/bugsnag/flutter/BugsnagFlutter.java
@@ -256,17 +256,19 @@ class BugsnagFlutter {
         return Bugsnag.getContext();
     }
 
-    @Nullable String setGroupingDiscriminator(@Nullable JSONObject args) {
+    @Nullable
+    String setGroupingDiscriminator(@Nullable JSONObject args) {
         String value = args != null ? getString(args, "value") : null;
         return Bugsnag.setGroupingDiscriminator(value);
     }
 
-    @Nullable String getGroupingDiscriminator(@Nullable JSONObject args) {
+    @Nullable
+    String getGroupingDiscriminator(@Nullable JSONObject args) {
         return Bugsnag.getGroupingDiscriminator(); // may be null
     }
 
     Boolean isStarted(@Nullable JSONObject args) {
-        return isStarted;
+        return InternalHooks.getClient() != null;
     }
 
     Void leaveBreadcrumb(@Nullable JSONObject args) throws Exception {
@@ -309,7 +311,7 @@ class BugsnagFlutter {
     }
 
     Void addMetadata(@Nullable JSONObject args) throws JSONException {
-        if (args == null || !hasString(args,"section") || !args.has("metadata")) {
+        if (args == null || !hasString(args, "section") || !args.has("metadata")) {
             return null;
         }
 
@@ -448,7 +450,7 @@ class BugsnagFlutter {
                     long spanIdAsLong = hexToLong(spanId);
                     event.setTraceCorrelation(new UUID(traceIdMostSignificantBits, traceIdLeastSignificantBits), spanIdAsLong);
                 }
-            } catch(Exception e) {
+            } catch (Exception e) {
                 // ignore the error, the error correlation will be missing
             }
         }
@@ -476,12 +478,14 @@ class BugsnagFlutter {
         return null;
     }
 
-    @Nullable String getString(JSONObject args, String key) {
+    @Nullable
+    String getString(JSONObject args, String key) {
         Object value = args.opt(key);
         return value instanceof String ? (String) value : null;
     }
 
-    @Nullable String getString(JSONObject args, String key, @Nullable String fallback) {
+    @Nullable
+    String getString(JSONObject args, String key, @Nullable String fallback) {
         String value = getString(args, key);
         return value != null ? value : fallback;
     }

--- a/packages/bugsnag_flutter/android/src/main/java/com/bugsnag/flutter/BugsnagFlutterPlugin.java
+++ b/packages/bugsnag_flutter/android/src/main/java/com/bugsnag/flutter/BugsnagFlutterPlugin.java
@@ -45,6 +45,7 @@ public class BugsnagFlutterPlugin implements FlutterPlugin, MethodCallHandler {
         addFunction("start",                bugsnag::start);
         addFunction("setGroupingDiscriminator", bugsnag::setGroupingDiscriminator);
         addFunction("getGroupingDiscriminator", bugsnag::getGroupingDiscriminator);
+        addFunction("isStarted",            bugsnag::isStarted);
     }
 
     private <T> void addFunction(String name, BSGFunction<T> function) {

--- a/packages/bugsnag_flutter/ios/Classes/BugsnagFlutterPlugin.m
+++ b/packages/bugsnag_flutter/ios/Classes/BugsnagFlutterPlugin.m
@@ -194,7 +194,7 @@ static NSArray *jsonToRegularExpressions(NSArray *source) {
 }
 
 - (NSNumber *)isStarted:(NSDictionary *)arguments {
-    return @(self.isStarted);
+    return @([Bugsnag client] != nil);
 }
 
 - (void)leaveBreadcrumb:(NSDictionary *)arguments {

--- a/packages/bugsnag_flutter/ios/Classes/BugsnagFlutterPlugin.m
+++ b/packages/bugsnag_flutter/ios/Classes/BugsnagFlutterPlugin.m
@@ -193,6 +193,10 @@ static NSArray *jsonToRegularExpressions(NSArray *source) {
     return [Bugsnag groupingDiscriminator]; // may be nil
 }
 
+- (NSNumber *)isStarted:(NSDictionary *)arguments {
+    return @(self.isStarted);
+}
+
 - (void)leaveBreadcrumb:(NSDictionary *)arguments {
     [Bugsnag leaveBreadcrumbWithMessage:arguments[@"name"]
                                metadata:arguments[@"metaData"]

--- a/packages/bugsnag_flutter/ios/Classes/BugsnagFlutterProtocol.h
+++ b/packages/bugsnag_flutter/ios/Classes/BugsnagFlutterProtocol.h
@@ -36,4 +36,6 @@
 - (NSString * _Nullable)setGroupingDiscriminator:(NSDictionary *)arguments;
 - (NSString * _Nullable)getGroupingDiscriminator:(NSDictionary *)arguments;
 
+- (NSNumber *)isStarted:(NSDictionary *)arguments;
+
 @end

--- a/packages/bugsnag_flutter/lib/src/client.dart
+++ b/packages/bugsnag_flutter/lib/src/client.dart
@@ -25,6 +25,18 @@ final _notifier = {
 abstract class BugsnagClient {
   final Map<String, Stopwatch> _openNetworkRequests = {};
 
+  /// Whether Bugsnag has been initialized via [start] or [attach].
+  ///
+  /// Returns `true` if initialized, `false` otherwise. Use this to safely check
+  /// before calling other Bugsnag methods without try/catch blocks.
+  ///
+  /// ```dart
+  /// if (bugsnag.isStarted) {
+  ///   await bugsnag.setContext('my-screen');
+  /// }
+  /// ```
+  bool get isStarted;
+
   /// An utility error handling function that will send reported errors to
   /// Bugsnag as unhandled. The [errorHandler] is suitable for use with
   /// common Dart error callbacks such as [runZonedGuarded] or [Future.onError].
@@ -324,6 +336,9 @@ mixin DelegateClient implements BugsnagClient {
   }
 
   @override
+  bool get isStarted => _client != null;
+
+  @override
   void Function(dynamic error, StackTrace? stack) get errorHandler =>
       client.errorHandler;
 
@@ -419,6 +434,7 @@ mixin DelegateClient implements BugsnagClient {
 class ChannelClient extends BugsnagClient {
   FlutterExceptionHandler? _previousFlutterOnError;
   ErrorCallback? _previousPlatformDispatcherOnError;
+  bool _isStarted = false;
 
   ChannelClient(bool autoDetectErrors) {
     if (autoDetectErrors) {
@@ -437,6 +453,9 @@ class ChannelClient extends BugsnagClient {
   final CallbackCollection<BugsnagEvent> _onErrorCallbacks = {};
 
   final contextProvider = BugsnagContextProviderImpl();
+
+  @override
+  bool get isStarted => _isStarted;
 
   @override
   void Function(dynamic error, StackTrace? stack) get errorHandler =>
@@ -739,6 +758,7 @@ class Bugsnag extends BugsnagClient with DelegateClient {
         result['config']['enabledErrorTypes']['dartErrors'] as bool;
 
     final client = ChannelClient(autoDetectErrors);
+    client._isStarted = true;
     client._onErrorCallbacks.addAll(onError);
     this.client = client;
   }
@@ -860,9 +880,10 @@ class Bugsnag extends BugsnagClient with DelegateClient {
       if (versionCode != null) 'versionCode': versionCode,
     });
 
-    final client = ChannelClient(detectDartErrors);
-    client._onErrorCallbacks.addAll(onError);
-    this.client = client;
+  final client = ChannelClient(detectDartErrors);
+  client._isStarted = true;
+  client._onErrorCallbacks.addAll(onError);
+  this.client = client;
 
     if (autoTrackSessions) {
       await resumeSession().onError((error, stackTrace) => true);

--- a/packages/bugsnag_flutter/lib/src/client.dart
+++ b/packages/bugsnag_flutter/lib/src/client.dart
@@ -25,7 +25,7 @@ final _notifier = {
 abstract class BugsnagClient {
   final Map<String, Stopwatch> _openNetworkRequests = {};
 
-  /// Whether Bugsnag has been initialized via [start] or [attach].
+  /// Whether Bugsnag has been initialized via [Bugsnag.start] or [Bugsnag.attach].
   ///
   /// Returns `true` if initialized, `false` otherwise. Use this to safely check
   /// before calling other Bugsnag methods without try/catch blocks.
@@ -457,6 +457,17 @@ class ChannelClient extends BugsnagClient {
   @override
   bool get isStarted => _isStarted;
 
+  Future<void> syncIsStarted({required bool fallback}) async {
+    try {
+      final started = await _channel.invokeMethod<bool>('isStarted');
+      _isStarted = started ?? fallback;
+    } catch (_) {
+      // Keep backward compatibility if the native side does not expose
+      // isStarted in older host apps.
+      _isStarted = fallback;
+    }
+  }
+
   @override
   void Function(dynamic error, StackTrace? stack) get errorHandler =>
       _notifyUnhandled;
@@ -758,7 +769,7 @@ class Bugsnag extends BugsnagClient with DelegateClient {
         result['config']['enabledErrorTypes']['dartErrors'] as bool;
 
     final client = ChannelClient(autoDetectErrors);
-    client._isStarted = true;
+    await client.syncIsStarted(fallback: true);
     client._onErrorCallbacks.addAll(onError);
     this.client = client;
   }
@@ -881,7 +892,7 @@ class Bugsnag extends BugsnagClient with DelegateClient {
     });
 
     final client = ChannelClient(detectDartErrors);
-    client._isStarted = true;
+    await client.syncIsStarted(fallback: true);
     client._onErrorCallbacks.addAll(onError);
     this.client = client;
 

--- a/packages/bugsnag_flutter/lib/src/client.dart
+++ b/packages/bugsnag_flutter/lib/src/client.dart
@@ -880,10 +880,10 @@ class Bugsnag extends BugsnagClient with DelegateClient {
       if (versionCode != null) 'versionCode': versionCode,
     });
 
-  final client = ChannelClient(detectDartErrors);
-  client._isStarted = true;
-  client._onErrorCallbacks.addAll(onError);
-  this.client = client;
+    final client = ChannelClient(detectDartErrors);
+    client._isStarted = true;
+    client._onErrorCallbacks.addAll(onError);
+    this.client = client;
 
     if (autoTrackSessions) {
       await resumeSession().onError((error, stackTrace) => true);

--- a/packages/bugsnag_flutter/test/bugsnag_test.dart
+++ b/packages/bugsnag_flutter/test/bugsnag_test.dart
@@ -17,6 +17,7 @@ void main() {
           'enabledErrorTypes': {'dartErrors': true}
         }
       };
+      channel.results['isStarted'] = true;
 
       await bugsnag.attach();
 
@@ -25,6 +26,7 @@ void main() {
 
     test('default projectPackages', () async {
       channel.results['start'] = true;
+      channel.results['isStarted'] = true;
       await bugsnag.start();
 
       // file "packages" are <unknown>
@@ -39,6 +41,7 @@ void main() {
 
     test('default telemetry', () async {
       channel.results['start'] = true;
+      channel.results['isStarted'] = true;
       await bugsnag.start();
 
       expect(
@@ -49,6 +52,7 @@ void main() {
 
     test('disabled internal errors only', () async {
       channel.results['start'] = true;
+      channel.results['isStarted'] = true;
       await bugsnag.start(
           telemetry: const BugsnagTelemetryTypes(internalErrors: false));
 
@@ -60,6 +64,7 @@ void main() {
 
     test('disabled telemetry', () async {
       channel.results['start'] = true;
+      channel.results['isStarted'] = true;
       await bugsnag.start(
           telemetry:
               const BugsnagTelemetryTypes(internalErrors: false, usage: false));

--- a/packages/bugsnag_flutter/test/endpoints_test.dart
+++ b/packages/bugsnag_flutter/test/endpoints_test.dart
@@ -25,6 +25,9 @@ Future<Map<String, dynamic>> _captureEndpoints(
         'config': {'enabledErrorTypes': {'dartErrors': true}}
       };
     }
+    if (call.method == 'isStarted') {
+      return true;
+    }
     return null;
   }
 

--- a/packages/bugsnag_flutter/test/is_started_test.dart
+++ b/packages/bugsnag_flutter/test/is_started_test.dart
@@ -1,0 +1,36 @@
+import 'package:bugsnag_flutter/src/client.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'test_channel.dart';
+
+void main() {
+  final channel = MockChannelClientController();
+
+  group('ChannelClient.isStarted', () {
+    setUp(() {
+      channel.reset();
+    });
+
+    test('ChannelClient has isStarted property that returns bool', () {
+      final client = ChannelClient(true);
+      
+      // isStarted should be accessible and return a bool
+      final isStarted = client.isStarted;
+      expect(isStarted, isA<bool>());
+      
+      // Initially should be false
+      expect(isStarted, isFalse);
+    });
+
+    test('ChannelClient.isStarted is false on new instances', () {
+      final client1 = ChannelClient(true);
+      final client2 = ChannelClient(false);
+      
+      expect(client1.isStarted, isFalse);
+      expect(client2.isStarted, isFalse);
+    });
+  });
+}
+
+
+

--- a/packages/bugsnag_flutter/test/is_started_test.dart
+++ b/packages/bugsnag_flutter/test/is_started_test.dart
@@ -6,18 +6,18 @@ import 'test_channel.dart';
 void main() {
   final channel = MockChannelClientController();
 
-  group('ChannelClient.isStarted', () {
+  group('isStarted', () {
     setUp(() {
       channel.reset();
     });
 
     test('ChannelClient has isStarted property that returns bool', () {
       final client = ChannelClient(true);
-      
+
       // isStarted should be accessible and return a bool
       final isStarted = client.isStarted;
       expect(isStarted, isA<bool>());
-      
+
       // Initially should be false
       expect(isStarted, isFalse);
     });
@@ -25,12 +25,33 @@ void main() {
     test('ChannelClient.isStarted is false on new instances', () {
       final client1 = ChannelClient(true);
       final client2 = ChannelClient(false);
-      
+
       expect(client1.isStarted, isFalse);
       expect(client2.isStarted, isFalse);
     });
+
+    test('bugsnag.start transitions isStarted to true', () async {
+      channel.results['start'] = true;
+
+      await bugsnag.start(autoTrackSessions: false);
+
+      expect(bugsnag.isStarted, isTrue);
+      expect((bugsnag.client as ChannelClient).isStarted, isTrue);
+      expect(channel['start'], hasLength(1));
+    });
+
+    test('bugsnag.attach transitions isStarted to true', () async {
+      channel.results['attach'] = {
+        'config': {
+          'enabledErrorTypes': {'dartErrors': true}
+        }
+      };
+
+      await bugsnag.attach();
+
+      expect(bugsnag.isStarted, isTrue);
+      expect((bugsnag.client as ChannelClient).isStarted, isTrue);
+      expect(channel['attach'], hasLength(1));
+    });
   });
 }
-
-
-

--- a/packages/bugsnag_flutter/test/is_started_test.dart
+++ b/packages/bugsnag_flutter/test/is_started_test.dart
@@ -32,12 +32,14 @@ void main() {
 
     test('bugsnag.start transitions isStarted to true', () async {
       channel.results['start'] = true;
+      channel.results['isStarted'] = true;
 
       await bugsnag.start(autoTrackSessions: false);
 
       expect(bugsnag.isStarted, isTrue);
       expect((bugsnag.client as ChannelClient).isStarted, isTrue);
       expect(channel['start'], hasLength(1));
+      expect(channel['isStarted'], hasLength(1));
     });
 
     test('bugsnag.attach transitions isStarted to true', () async {
@@ -46,12 +48,25 @@ void main() {
           'enabledErrorTypes': {'dartErrors': true}
         }
       };
+      channel.results['isStarted'] = true;
 
       await bugsnag.attach();
 
       expect(bugsnag.isStarted, isTrue);
       expect((bugsnag.client as ChannelClient).isStarted, isTrue);
       expect(channel['attach'], hasLength(1));
+      expect(channel['isStarted'], hasLength(1));
+    });
+
+    test('bugsnag.start falls back to started=true if platform isStarted is unavailable', () async {
+      channel.results['start'] = true;
+
+      await bugsnag.start(autoTrackSessions: false);
+
+      expect(bugsnag.isStarted, isTrue);
+      expect((bugsnag.client as ChannelClient).isStarted, isTrue);
+      expect(channel['start'], hasLength(1));
+      expect(channel['isStarted'], hasLength(1));
     });
   });
 }


### PR DESCRIPTION
- Added `isStarted` getter to `BugsnagClient` to allow checking if the SDK has been initialized via `start` or `attach`.
- Implemented `isStarted` in `ChannelClient` and `DelegateClient`.
- Updated `Bugsnag.start()` and `Bugsnag.attach()` to set the started state.
- Added platform channel support for `isStarted` on Android and iOS.
- Added unit tests and a new integration scenario `CallBugsnagBeforeStartScenario`.

## Goal

Provide a way to programmatically check if the Bugsnag SDK has been initialized to prevent calling methods before start or attach.

## Design

Added an isStarted property to the Dart BugsnagClient and synchronized it with native platform states via existing method channels.

## Changeset

Implemented isStarted in Dart, Android, and iOS layers, and added a new integration scenario to the test fixture.

## Testing

Verified initialization state transitions using new unit tests in is_started_test and the CallBugsnagBeforeStartScenario integration test.